### PR TITLE
standardize and document global option names, closes #82

### DIFF
--- a/R/posterior-package.R
+++ b/R/posterior-package.R
@@ -25,4 +25,15 @@
 #' * Provide lightweight implementations of state of the art posterior inference
 #' diagnostics.
 #'
+#' @section Package options:
+#'
+#' The following options are used to format and print [draws] objects,
+#' as in `print.draws_array()`, `print.draws_df()`, `print.draws_list()`,
+#' and `print.draws_matrix()`:
+#'
+#' * `posterior.max_draws`: Maximum number of draws to print.
+#' * `posterior.max_iterations`: Maximum number of iterations to print.
+#' * `posterior.max_chains`: Maximum number of chains to print.
+#' * `posterior.max_variables`: Maximum number of variables to print.
+#'
 NULL

--- a/R/print.R
+++ b/R/print.R
@@ -15,8 +15,8 @@
 #'
 #' @export
 print.draws_matrix <- function(x, digits = 2,
-                               max_draws = getOption("max_draws", 10),
-                               max_variables = getOption("max_variables", 8),
+                               max_draws = getOption("posterior.max_draws", 10),
+                               max_variables = getOption("posterior.max_variables", 8),
                                ...) {
   max_draws <- as_one_integer(max_draws)
   max_variables <- as_one_integer(max_variables)
@@ -67,9 +67,9 @@ print.draws_matrix <- function(x, digits = 2,
 #'
 #' @export
 print.draws_array <- function(x, digits = 2,
-                              max_iterations = getOption("max_iterations", 5),
-                              max_chains = getOption("max_chains", 8),
-                              max_variables = getOption("max_variables", 4),
+                              max_iterations = getOption("posterior.max_iterations", 5),
+                              max_chains = getOption("posterior.max_chains", 8),
+                              max_variables = getOption("posterior.max_variables", 4),
                               ...) {
   max_iterations <- as_one_integer(max_iterations)
   max_chains <- as_one_integer(max_chains)
@@ -128,8 +128,8 @@ print.draws_array <- function(x, digits = 2,
 #'
 #' @export
 print.draws_df <- function(x, digits = 2,
-                           max_draws = getOption("max_draws", 10),
-                           max_variables = getOption("max_variables", 8),
+                           max_draws = getOption("posterior.max_draws", 10),
+                           max_variables = getOption("posterior.max_variables", 8),
                            meta_columns = FALSE, ...) {
   max_draws <- as_one_integer(max_draws)
   max_variables <- as_one_integer(max_variables)
@@ -191,9 +191,9 @@ print.draws_df <- function(x, digits = 2,
 #'
 #' @export
 print.draws_list <- function(x, digits = 2,
-                             max_iterations = getOption("max_iterations", 10),
-                             max_chains = getOption("max_chains", 2),
-                             max_variables = getOption("max_variables", 4),
+                             max_iterations = getOption("posterior.max_iterations", 10),
+                             max_chains = getOption("posterior.max_chains", 2),
+                             max_variables = getOption("posterior.max_variables", 4),
                              ...) {
   max_iterations <- as_one_integer(max_iterations)
   max_chains <- as_one_integer(max_chains)

--- a/man-roxygen/args-print-max_chains.R
+++ b/man-roxygen/args-print-max_chains.R
@@ -1,3 +1,3 @@
 #' @param max_chains Maximum number of chains to print.
-#' Can be controlled globally via the `"max_chains"` option
+#' Can be controlled globally via the `"posterior.max_chains"` option
 #' (see [`options`] details).

--- a/man-roxygen/args-print-max_draws.R
+++ b/man-roxygen/args-print-max_draws.R
@@ -1,3 +1,3 @@
 #' @param max_draws Maximum number of draws to print.
-#' Can be controlled globally via the `"max_draws"` option
+#' Can be controlled globally via the `"posterior.max_draws"` option
 #' (see [`options`] details).

--- a/man-roxygen/args-print-max_iterations.R
+++ b/man-roxygen/args-print-max_iterations.R
@@ -1,3 +1,3 @@
 #' @param max_iterations Maximum number of iterations to print.
-#' Can be controlled globally via the `"max_iterations"` option
+#' Can be controlled globally via the `"posterior.max_iterations"` option
 #' (see [`options`] for details).

--- a/man-roxygen/args-print-max_variables.R
+++ b/man-roxygen/args-print-max_variables.R
@@ -1,3 +1,3 @@
 #' @param max_variables Maximum number of variables to print.
-#' Can be controlled globally via the `"max_variables"` option
+#' Can be controlled globally via the `"posterior.max_variables"` option
 #' (see [`options`] for details).

--- a/man/posterior-package.Rd
+++ b/man/posterior-package.Rd
@@ -25,3 +25,17 @@ for example, subsetting, binding, or mutating draws.
 diagnostics.
 }
 }
+\section{Package options}{
+
+
+The following options are used to format and print \link{draws} objects,
+as in \code{print.draws_array()}, \code{print.draws_df()}, \code{print.draws_list()},
+and \code{print.draws_matrix()}:
+\itemize{
+\item \code{posterior.max_draws}: Maximum number of draws to print.
+\item \code{posterior.max_iterations}: Maximum number of iterations to print.
+\item \code{posterior.max_chains}: Maximum number of chains to print.
+\item \code{posterior.max_variables}: Maximum number of variables to print.
+}
+}
+

--- a/man/print.draws_array.Rd
+++ b/man/print.draws_array.Rd
@@ -7,9 +7,9 @@
 \method{print}{draws_array}(
   x,
   digits = 2,
-  max_iterations = getOption("max_iterations", 5),
-  max_chains = getOption("max_chains", 8),
-  max_variables = getOption("max_variables", 4),
+  max_iterations = getOption("posterior.max_iterations", 5),
+  max_chains = getOption("posterior.max_chains", 8),
+  max_variables = getOption("posterior.max_variables", 4),
   ...
 )
 }
@@ -19,15 +19,15 @@
 \item{digits}{Minimum number of significant digits to print.}
 
 \item{max_iterations}{Maximum number of iterations to print.
-Can be controlled globally via the \code{"max_iterations"} option
+Can be controlled globally via the \code{"posterior.max_iterations"} option
 (see \code{\link{options}} for details).}
 
 \item{max_chains}{Maximum number of chains to print.
-Can be controlled globally via the \code{"max_chains"} option
+Can be controlled globally via the \code{"posterior.max_chains"} option
 (see \code{\link{options}} details).}
 
 \item{max_variables}{Maximum number of variables to print.
-Can be controlled globally via the \code{"max_variables"} option
+Can be controlled globally via the \code{"posterior.max_variables"} option
 (see \code{\link{options}} for details).}
 
 \item{...}{Further arguments passed to the underlying \code{\link{print}} methods.}

--- a/man/print.draws_df.Rd
+++ b/man/print.draws_df.Rd
@@ -7,8 +7,8 @@
 \method{print}{draws_df}(
   x,
   digits = 2,
-  max_draws = getOption("max_draws", 10),
-  max_variables = getOption("max_variables", 8),
+  max_draws = getOption("posterior.max_draws", 10),
+  max_variables = getOption("posterior.max_variables", 8),
   meta_columns = FALSE,
   ...
 )
@@ -19,11 +19,11 @@
 \item{digits}{Minimum number of significant digits to print.}
 
 \item{max_draws}{Maximum number of draws to print.
-Can be controlled globally via the \code{"max_draws"} option
+Can be controlled globally via the \code{"posterior.max_draws"} option
 (see \code{\link{options}} details).}
 
 \item{max_variables}{Maximum number of variables to print.
-Can be controlled globally via the \code{"max_variables"} option
+Can be controlled globally via the \code{"posterior.max_variables"} option
 (see \code{\link{options}} for details).}
 
 \item{meta_columns}{Logical. Show the meta-columns \code{.chain},

--- a/man/print.draws_list.Rd
+++ b/man/print.draws_list.Rd
@@ -7,9 +7,9 @@
 \method{print}{draws_list}(
   x,
   digits = 2,
-  max_iterations = getOption("max_iterations", 10),
-  max_chains = getOption("max_chains", 2),
-  max_variables = getOption("max_variables", 4),
+  max_iterations = getOption("posterior.max_iterations", 10),
+  max_chains = getOption("posterior.max_chains", 2),
+  max_variables = getOption("posterior.max_variables", 4),
   ...
 )
 }
@@ -19,15 +19,15 @@
 \item{digits}{Minimum number of significant digits to print.}
 
 \item{max_iterations}{Maximum number of iterations to print.
-Can be controlled globally via the \code{"max_iterations"} option
+Can be controlled globally via the \code{"posterior.max_iterations"} option
 (see \code{\link{options}} for details).}
 
 \item{max_chains}{Maximum number of chains to print.
-Can be controlled globally via the \code{"max_chains"} option
+Can be controlled globally via the \code{"posterior.max_chains"} option
 (see \code{\link{options}} details).}
 
 \item{max_variables}{Maximum number of variables to print.
-Can be controlled globally via the \code{"max_variables"} option
+Can be controlled globally via the \code{"posterior.max_variables"} option
 (see \code{\link{options}} for details).}
 
 \item{...}{Further arguments passed to the underlying \code{\link{print}} methods.}

--- a/man/print.draws_matrix.Rd
+++ b/man/print.draws_matrix.Rd
@@ -7,8 +7,8 @@
 \method{print}{draws_matrix}(
   x,
   digits = 2,
-  max_draws = getOption("max_draws", 10),
-  max_variables = getOption("max_variables", 8),
+  max_draws = getOption("posterior.max_draws", 10),
+  max_variables = getOption("posterior.max_variables", 8),
   ...
 )
 }
@@ -18,11 +18,11 @@
 \item{digits}{Minimum number of significant digits to print.}
 
 \item{max_draws}{Maximum number of draws to print.
-Can be controlled globally via the \code{"max_draws"} option
+Can be controlled globally via the \code{"posterior.max_draws"} option
 (see \code{\link{options}} details).}
 
 \item{max_variables}{Maximum number of variables to print.
-Can be controlled globally via the \code{"max_variables"} option
+Can be controlled globally via the \code{"posterior.max_variables"} option
 (see \code{\link{options}} for details).}
 
 \item{...}{Further arguments passed to the underlying \code{\link{print}} methods.}


### PR DESCRIPTION
This prefixes global options with `"posterior."` and documents them in `posterior-package`. Closes #82.