### PR TITLE
Fix Blom 1958 reference

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -447,7 +447,7 @@ r_scale <- function(x) {
 #' Backtransformation of ranks
 #'
 #' @param r array of ranks
-#' @param c fractional offset; defaults to c = 3/8 as recommend by Bloom (1985)
+#' @param c fractional offset; defaults to c = 3/8 as recommend by Blom (1958)
 #' @noRd
 backtransform_ranks <- function(r, c = 3/8) {
   S <- length(r)


### PR DESCRIPTION
This PR fixes the reference.

This came up in https://github.com/arviz-devs/arviz/pull/1366#discussion_r479935719

Thanks @avehtari for the correction.