### PR TITLE
Special case as_draws_array for length 1

### DIFF
--- a/R/as_draws_array.R
+++ b/R/as_draws_array.R
@@ -60,7 +60,7 @@ as_draws_array.draws_df <- function(x, ...) {
     if (length(chains) == 1) {
       out[[i]] <- x
     } else {
-      out[[i]] <- x[x$.chain == i, ]      
+      out[[i]] <- x[x$.chain == i, ]
     }
     out[[i]] <- remove_reserved_df_variables(out[[i]])
     out[[i]] <- as.matrix(out[[i]])
@@ -161,7 +161,14 @@ is_draws_array_like <- function(x) {
 # convert a list of matrices to an array
 as_array_matrix_list <- function(x) {
   stopifnot(is.list(x))
-  x <- abind::abind(x, along = 3L)
+  if (length(x) == 1) {
+    tmp <- dimnames(x[[1]])
+    x <- x[[1]]
+    dim(x) <- c(dim(x), 1)
+    dimnames(x) <- tmp
+  } else {
+    x <- abind::abind(x, along = 3L)
+  }
   x <- aperm(x, c(1, 3, 2))
 }
 
@@ -183,3 +190,4 @@ empty_draws_array <- function(variables = character(0), nchains = 0,
   class(out) <- class_draws_array()
   out
 }
+

--- a/R/as_draws_array.R
+++ b/R/as_draws_array.R
@@ -161,12 +161,7 @@ is_draws_array_like <- function(x) {
 # convert a list of matrices to an array
 as_array_matrix_list <- function(x) {
   stopifnot(is.list(x))
-  if (length(x) == 1) {
-    x <- x[[1]]
-    dim(x) <- c(dim(x), 1)
-  } else {
-    x <- abind::abind(x, along = 3L)
-  }  
+  x <- abind::abind(x, along = 3L)
   x <- aperm(x, c(1, 3, 2))
 }
 

--- a/R/as_draws_array.R
+++ b/R/as_draws_array.R
@@ -57,7 +57,11 @@ as_draws_array.draws_df <- function(x, ...) {
   chains <- chain_ids(x)
   out <- vector("list", length(chains))
   for (i in seq_along(out)) {
-    out[[i]] <- x[x$.chain == i, ]
+    if (length(chains) == 1) {
+      out[[i]] <- x
+    } else {
+      out[[i]] <- x[x$.chain == i, ]      
+    }
     out[[i]] <- remove_reserved_df_variables(out[[i]])
     out[[i]] <- as.matrix(out[[i]])
   }
@@ -157,7 +161,12 @@ is_draws_array_like <- function(x) {
 # convert a list of matrices to an array
 as_array_matrix_list <- function(x) {
   stopifnot(is.list(x))
-  x <- abind::abind(x, along = 3L)
+  if (length(x) == 1) {
+    x <- x[[1]]
+    dim(x) <- c(dim(x), 1)
+  } else {
+    x <- abind::abind(x, along = 3L)
+  }  
   x <- aperm(x, c(1, 3, 2))
 }
 


### PR DESCRIPTION
When we use as_draws_array and we only have 1 chain we could optimize the function a bit. 

Testing scenario: 
```r
library(cmdstanr)
model_code <- "
parameters {
  real k;
}

transformed parameters {
  real x[50000] = rep_array(k, 50000);
}

model {
  k ~ normal(0, 1);
}
"
model_file <- write_stan_file(model_code)
mod <- cmdstan_model(model_file)
fit <- mod$sample(iter_sampling = 2000, validate_csv = FALSE, chains = 1)

data <- data.table::fread(cmd= paste0("grep -v '^#' ", fit$output_files()[1]))

times <- c()
for (i in 1:10) {
  start <- Sys.time()
  d_a <- posterior::as_draws_array(data)
  times <- c(times, as.double((Sys.time()-start), units = "secs"))
}
print(times)
```

this branch:
```
1.838615 1.740373 1.687281 1.830399 1.704403 1.841837 1.646028 1.733209 1.632276 1.731928
```
mean 1.74s

master:
```
2.565165 2.900125 2.978846 2.799916 2.859506 3.029445 2.660265 2.807306 2.583319 2.838322
```
mean 2.8s

So roughly 40% faster. 

This is important for cmdstanr where we read results one chain at a time. But probably makes sense anyway.
I am looking into other bottlenecks so if you prefer to review in larger chunks we can keep the PR open and I can note when I am done.