### PR TITLE
allow drop=TRUE for draws_array

### DIFF
--- a/R/as_draws_array.R
+++ b/R/as_draws_array.R
@@ -154,7 +154,7 @@ is_draws_array_like <- function(x) {
   # TODO: allow for argument 'reserved' as in '[.draws_df'
   #   right now this fails because NextMethod() cannot ignore arguments
   out <- NextMethod("[", drop = drop)
-  if (length(dim(out)) == 3) {
+  if (length(dim(out)) == length(dim(x))) {
     class(out) <- class(x)
   }
   out

--- a/R/as_draws_array.R
+++ b/R/as_draws_array.R
@@ -150,10 +150,10 @@ is_draws_array_like <- function(x) {
 
 #' @export
 `[.draws_array` <- function(x, i, j, ..., drop = FALSE) {
-  # TODO: add a warning that 'drop' is ignored?
+  # TODO: add a warning that 'drop' can lead to also dropping the class?
   # TODO: allow for argument 'reserved' as in '[.draws_df'
   #   right now this fails because NextMethod() cannot ignore arguments
-  out <- NextMethod("[", drop = FALSE)
+  out <- NextMethod("[")
   class(out) <- class(x)
   out
 }

--- a/R/as_draws_array.R
+++ b/R/as_draws_array.R
@@ -153,8 +153,10 @@ is_draws_array_like <- function(x) {
   # TODO: add a warning that 'drop' can lead to also dropping the class?
   # TODO: allow for argument 'reserved' as in '[.draws_df'
   #   right now this fails because NextMethod() cannot ignore arguments
-  out <- NextMethod("[")
-  class(out) <- class(x)
+  out <- NextMethod("[", drop = drop)
+  if (length(dim(out)) == 3) {
+    class(out) <- class(x)
+  }
   out
 }
 

--- a/R/as_draws_matrix.R
+++ b/R/as_draws_matrix.R
@@ -126,11 +126,13 @@ is_draws_matrix_like <- function(x) {
 
 #' @export
 `[.draws_matrix` <- function(x, i, j, ..., drop = FALSE) {
-  # TODO: add a warning that 'drop' is ignored?
+  # TODO: add a warning that 'drop' can lead to also dropping the class?
   # TODO: allow for argument 'reserved' as in '[.draws_df'
   #   right now this fails because NextMethod() cannot ignore arguments
-  out <- NextMethod("[", drop = FALSE)
-  class(out) <- class(x)
+  out <- NextMethod("[", drop = drop)
+  if (length(dim(out)) == length(dim(x))) {
+    class(out) <- class(x)
+  }
   out
 }
 

--- a/tests/testthat/test-draws-index.R
+++ b/tests/testthat/test-draws-index.R
@@ -88,3 +88,16 @@ test_that("indexing draws_array with [ and drop works correctly", {
   expect_s3_class(x3, "draws_array")
 })
 
+test_that("indexing draws_matrix with [ and drop works correctly", {
+  x <- as_draws_matrix(example_draws())
+  x1 <- x[,1]
+  x2 <- x[,1, drop=TRUE]
+  expect_s3_class(x1, "draws_matrix")
+  expect_equal(class(x2), "numeric")
+  expect_length(dim(x1), 2)
+  expect_null(dim(x2))
+
+  # drop=TRUE shouldn't do anything if multiple parameters selected
+  x3 <- x[,1:2, drop=TRUE]
+  expect_s3_class(x3, "draws_matrix")
+})

--- a/tests/testthat/test-draws-index.R
+++ b/tests/testthat/test-draws-index.R
@@ -74,7 +74,11 @@ test_that("indexing draws_array with [ and drop works correctly", {
   x1 <- x[,,1]
   x2 <- x[,,1, drop=TRUE]
   expect_s3_class(x1, "draws_array")
-  expect_equal(class(x2), c("matrix", "array"))
+  if (R.version$major >= "4") {
+    expect_equal(class(x2), c("matrix", "array"))
+  } else {
+    expect_equal(class(x2), "matrix")
+  }
   expect_length(dim(x1), 3)
   expect_length(dim(x2), 2)
   expect_equal(x2, extract_variable_matrix(x, "mu"))

--- a/tests/testthat/test-draws-index.R
+++ b/tests/testthat/test-draws-index.R
@@ -69,3 +69,18 @@ test_that("indices of draws_list objects are correct", {
   expect_equal(chain_ids(x), 1:length(x))
 })
 
+test_that("indexing draws_array with [ and drop works correctly", {
+  x <- example_draws()
+  x1 <- x[,,1]
+  x2 <- x[,,1, drop=TRUE]
+  expect_s3_class(x1, "draws_array")
+  expect_equal(class(x2), c("matrix", "array"))
+  expect_length(dim(x1), 3)
+  expect_length(dim(x2), 2)
+  expect_equal(x2, extract_variable_matrix(x, "mu"))
+
+  # drop=TRUE shouldn't do anything if multiple parameters selected
+  x3 <- x[,,1:2, drop=TRUE]
+  expect_s3_class(x3, "draws_array")
+})
+


### PR DESCRIPTION
Allows drop=TRUE when indexing draws_array objects as discussed in https://github.com/stan-dev/loo/pull/161. 