### PR TITLE
Don't munge names in draws_df

### DIFF
--- a/R/as_draws_df.R
+++ b/R/as_draws_df.R
@@ -196,7 +196,7 @@ draws_df <- function(..., .nchains = 1) {
     stop2("Number of chains does not divide the number of draws.")
   }
   niterations <- ndraws %/% .nchains
-  out <- as.data.frame(out)
+  out <- as.data.frame(out, optional = TRUE)
   out$.iteration <- rep(1L:niterations, .nchains)
   out$.chain <- rep(1L:.nchains, each = niterations)
   as_draws_df(out)

--- a/tests/testthat/test-as_draws.R
+++ b/tests/testthat/test-as_draws.R
@@ -242,3 +242,8 @@ test_that("draws_* constructors throw correct errors", {
   expect_error(draws_df(a = 1, .nchains = 2), "Number of chains does not divide the number of draws")
   expect_error(draws_list(a = 1, .nchains = 2), "Number of chains does not divide the number of draws")
 })
+
+test_that("draws_df does not munge variable names", {
+  draws_df <- draws_df(`x[1]` = 1:2, `x[2]` = 3:4)
+  expect_equal(variables(draws_df), c("x[1]", "x[2]"))
+})


### PR DESCRIPTION
`draws_df()` currently munges syntactically invalid names via a call down to `as.data.frame()` in a way that makes usage with indexed variables annoying:

```r
> draws_df(`x[1]` = 1:2, `x[2]` = 3:4)
# A draws_df: 2 iterations, 1 chains, and 2 variables
  x.1. x.2.
1    1    3
2    2    4
# ... hidden reserved variables {'.chain', '.iteration', '.draw'}
```

This PR fixes it:

```r
> draws_df(`x[1]` = 1:2, `x[2]` = 3:4)
# A draws_df: 2 iterations, 1 chains, and 2 variables
  x[1] x[2]
1    1    3
2    2    4
# ... hidden reserved variables {'.chain', '.iteration', '.draw'}
```