### PR TITLE
make subset_draws efficient

### DIFF
--- a/R/draws-index.R
+++ b/R/draws-index.R
@@ -430,22 +430,21 @@ check_existing_variables <- function(variables, x, regex = FALSE,
   if (regex) {
     tmp <- named_list(variables)
     for (i in seq_along(variables)) {
-      tmp[[i]] <- all_variables[grepl(variables[i], all_variables)]
+      tmp[[i]] <- grep(variables[i], all_variables)
     }
     # regular expressions are not required to match anything
     missing_variables <- NULL
-    variables <- as.character(unique(unlist(tmp)))
+    variables <- as.character(all_variables[unique(unlist(tmp))])
   } else if (!scalar_only) {
-    tmp <- named_list(variables)
-    escaped_variables <- escape_all(variables)
-    missing <- rep(NA, length(variables))
-    for (i in seq_along(variables)) {
-      v_regex <- paste0("^", escaped_variables[i], "(\\[.*\\])?$")
-      tmp[[i]] <- all_variables[grepl(v_regex, all_variables)]
-      missing[i] <- !length(tmp[[i]])
-    }
-    missing_variables <- variables[missing]
-    variables <- as.character(unique(unlist(tmp)))
+    missing_candidates <- setdiff(variables, all_variables)
+    all_variables_base <- gsub("\\[.*\\]$", "", all_variables)
+    missing_variables <- setdiff(missing_candidates, all_variables_base)
+    vector_variables <- setdiff(missing_candidates, missing_variables)
+    variables <- unique(
+      c(variables[!(variables %in% missing_candidates)],
+        all_variables[all_variables_base %in% vector_variables])
+    )
+    variables <- variables[order(match(variables, all_variables))]
   } else {
     missing_variables <- setdiff(variables, all_variables)
   }

--- a/tests/testthat/test-subset_draws.R
+++ b/tests/testthat/test-subset_draws.R
@@ -111,3 +111,20 @@ test_that("variables can be subsetted via non-scalar selection", {
   x_sub <- subset_draws(x, variable = "theta")
   expect_equal(variables(x_sub), c(paste0("theta[", 1:8, "]")))
 })
+
+test_that("subset_draws speed is tolerable with many variables", {
+  x <- as_draws_matrix(matrix(rnorm(10 * 300000), nrow = 10))
+  tt <- system.time(x2 <- subset_draws(x, colnames(x)))
+  expect_equal(x, x2)
+  expect_lt(tt[["elapsed"]], 1)
+})
+
+test_that("subset_draws speed is tolerable with many variables", {
+  x <- as_draws_matrix(example_draws())
+  expect_error(
+    subset_draws(x, variable = c("theta[2]", "X", "theta[3]", "Y")),
+    "The following variables are missing in the draws object: {'X', 'Y'}",
+    fixed = TRUE
+  )
+})
+


### PR DESCRIPTION
Addresses #129.

Makes `check_existing_variables()`, and therefore `subset_draws()` much more efficient. For example, with default arguments, this suggested version can process 300k variables in a fraction of a second while the current version takes almost 10 minutes. However, both versions still have comparable runtimes when  `regex = TRUE`.

```
x <- as_draws_matrix(matrix(rnorm(10 * 300000), nrow = 10, ncol = 300000))
microbenchmark::microbenchmark(
  posterior:::check_existing_variables(variables = colnames(x), x = x),
  posterior::subset_draws(x, variable = colnames(x)),
  times = 10,
  unit = "s"
)

Unit: seconds
       min        lq      mean    median        uq       max neval
 0.3240343 0.3354325 0.3669232 0.3541255 0.3870651 0.4765244    10
 0.4236527 0.4271074 0.4862439 0.4566513 0.5303358 0.6543742    10
```