### PR TITLE
updated drop_dims()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R: c(person("Paul-Christian", "Bürkner", email = "paul.buerkner@gmail.c
              person("Aki", "Vehtari", email = "Aki.Vehtari@aalto.fi", role = c("aut")),
              person("Måns", "Magnusson", role = c("ctb")),
              person("Rok", "Češnovar", role = c("ctb")),
-             person("Ben", "Lambert", role = c("ctb")))
+             person("Ben", "Lambert", role = c("ctb")),
+             person("Ozan", "Adıgüzel", role = c("ctb")))
 Description: Provides useful tools for both users and developers of packages 
   for fitting Bayesian models or working with output from Bayesian models. 
   The primary goals of the package are to: 

--- a/R/as_draws_df.R
+++ b/R/as_draws_df.R
@@ -83,7 +83,7 @@ as_draws_df.draws_array <- function(x, ...) {
   rownames(x) <- NULL
   out <- named_list(chain_ids)
   for (i in seq_along(out)) {
-    out[[i]] <- drop_dims(x[, i, ], dims = 2)
+    out[[i]] <- drop2(x[, i, ], dims = 2, reset_class = TRUE)
     class(out[[i]]) <- "matrix"
     out[[i]] <- tibble::as_tibble(out[[i]])
     out[[i]]$.chain <- chain_ids[i]

--- a/R/extract_variable_matrix.R
+++ b/R/extract_variable_matrix.R
@@ -32,7 +32,7 @@ extract_variable_matrix.draws <- function(x, variable, ...) {
   variable <- as_one_character(variable)
   out <- .subset_draws(x, variable = variable, reserved = FALSE)
   out <- as_draws_array(out)
-  out <- drop_dims(out, dims = 3)
+  out <- drop2(out, dims = 3, reset_class = TRUE)
   class(out) <- "matrix"
   out
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -27,22 +27,20 @@ seq_cols <- function(x) {
   seq_len(NCOL(x))
 }
 
-# selectively drop dimensions of arrays
+# selectively drop the dimensions of an array which have only one level
 drop_dims <- function(x, dims = NULL) {
   assert_array(x)
   assert_integerish(dims, null.ok = TRUE)
-  old_dims <- dim(x)
   if (is.null(dims)) {
-    dims <- old_dims[old_dims == 1L]
+    x <- drop(x)
   } else {
-    assert_true(all(old_dims[dims] <= 1L))
+    old_dims <- dim(x)
+    assert_true(all(old_dims[dims] == 1L))
+    old_dimnames <- dimnames(x)
+    dim(x) <- old_dims[-dims]
+    dimnames(x) <- old_dimnames[-dims]
   }
-  if (!length(dims)) {
-    return(x)
-  }
-  old_dimnames <- dimnames(x)
-  dim(x) <- old_dims[-dims]
-  dimnames(x) <- old_dimnames[-dims]
+  class(x) <- setdiff(class(x), "draws_array")
   x
 }
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -31,7 +31,7 @@ seq_cols <- function(x) {
 drop2 <- function(x, dims = NULL, reset_class = FALSE) {
   assert_array(x)
   assert_integerish(dims, null.ok = TRUE)
-  reset_class <- posterior:::as_one_logical(reset_class)
+  reset_class <- as_one_logical(reset_class)
   old_dims <- dim(x)
   # proceed to drop dimensions if the input array has any non-NULL dimensions
   if (length(old_dims)) {

--- a/R/rvar-.R
+++ b/R/rvar-.R
@@ -464,25 +464,6 @@ broadcast_draws <- function(x, .ndraws, keep_constants = FALSE) {
   }
 }
 
-drop_ <- function(x) {
-  .dim <- dim(x)
-
-  if (length(.dim) > 1) {
-    # with exactly 1 dimension left we don't want to drop anything
-    # (otherwise names get lost), so only do this with > 1 dimension
-    keep_dim <- .dim != 1
-    .dimnames <- dimnames(x)
-    dim(x) <- .dim[keep_dim]
-    # for comparison / testing, ensure if no dimnames have names that we
-    # actually have those names be NULL (rather than just empty strings)
-    new_dimnames <- .dimnames[keep_dim]
-    if (all(names(new_dimnames) == "")) names(new_dimnames) <- NULL
-    dimnames(x) <- new_dimnames
-  }
-
-  x
-}
-
 # flatten dimensions and names of an array
 flatten_array = function(x, x_name = NULL) {
   # determine new dimension names in the form x,y,z

--- a/R/rvar-slice.R
+++ b/R/rvar-slice.R
@@ -138,10 +138,9 @@
       if (all(names(new_dimnames) == "")) names(new_dimnames) <- NULL
       dimnames(x) <- new_dimnames
     }
-    x
-  } else {
-    x
   }
+
+  x
 }
 
 #' @export

--- a/R/rvar-slice.R
+++ b/R/rvar-slice.R
@@ -125,7 +125,20 @@
   ))
 
   if (drop) {
-    drop_(x)
+    .dim <- dim(x)
+    if (length(.dim) > 1) {
+      # with exactly 1 dimension left we don't want to drop anything
+      # (otherwise names get lost), so only do this with > 1 dimension
+      keep_dim <- .dim != 1
+      .dimnames <- dimnames(x)
+      dim(x) <- .dim[keep_dim]
+      # for comparison / testing, ensure if no dimnames have names that we
+      # actually have those names be NULL (rather than just empty strings)
+      new_dimnames <- .dimnames[keep_dim]
+      if (all(names(new_dimnames) == "")) names(new_dimnames) <- NULL
+      dimnames(x) <- new_dimnames
+    }
+    x
   } else {
     x
   }

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -126,7 +126,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   variables <- variables(x)
   out <- named_list(variables, values = list(named_list(names(funs))))
   for (v in variables) {
-    draws <- drop_dims(x[, , v], dims = 3)
+    draws <- drop2(x[, , v], dims = 3, reset_class = TRUE)
     args <- c(list(draws), .args)
     for (m in names(funs)) {
       out[[v]][[m]] <- do.call(funs[[m]], args)


### PR DESCRIPTION
Fixes #135.

- With default dims = NULL, `drop_dims()` drops all single-level dimensions as expected
- `drop_dims()`'s output excludes the `draws_array` class and therefore doesn't use the `print.draws_array` method