### PR TITLE
use more informative internal function names

### DIFF
--- a/R/as_draws.R
+++ b/R/as_draws.R
@@ -65,7 +65,7 @@ closest_draws_format <- function(x) {
     out <- "list"
   }
   else {
-    stop2("Don't know how to transform an object of class ",
+    stop_no_call("Don't know how to transform an object of class ",
           "'", class(x)[1L], "' to any supported draws format.")
   }
   paste0("draws_", out)
@@ -82,7 +82,7 @@ is_draws <- function(x) {
 # the validity of the 'draw' argument in 'subset'
 check_draws_object <- function(x) {
   if (!is_draws(x)) {
-    stop2("The object is not in a format supported by posterior.")
+    stop_no_call("The object is not in a format supported by posterior.")
   }
   x
 }
@@ -100,17 +100,17 @@ default_variables <- function(nvariables) {
 validate_draws_per_variable <- function(...) {
   out <- list(...)
   if (!rlang::is_named(out)) {
-    stop2("All variables must be named.")
+    stop_no_call("All variables must be named.")
   }
   if (".nchains" %in% names(out)) {
     # '.nchains' is an additional argument in chain supporting formats
-    stop2("'.nchains' is not supported for this format.")
+    stop_no_call("'.nchains' is not supported for this format.")
   }
   out <- lapply(out, as.numeric)
   ndraws_per_variable <- lengths(out)
   ndraws <- max(ndraws_per_variable)
   if (!all(ndraws_per_variable %in% c(1, ndraws))) {
-    stop2("Number of draws per variable needs to be 1 or ", ndraws, ".")
+    stop_no_call("Number of draws per variable needs to be 1 or ", ndraws, ".")
   }
   for (i in which(ndraws_per_variable == 1)) {
     out[[i]] <- rep(out[[i]], ndraws)

--- a/R/as_draws_array.R
+++ b/R/as_draws_array.R
@@ -142,11 +142,11 @@ draws_array <- function(..., .nchains = 1) {
   out <- validate_draws_per_variable(...)
   .nchains <- as_one_integer(.nchains)
   if (.nchains < 1) {
-    stop2("Number of chains must be positive.")
+    stop_no_call("Number of chains must be positive.")
   }
   ndraws <- length(out[[1]])
   if (ndraws %% .nchains != 0) {
-    stop2("Number of chains does not divide the number of draws.")
+    stop_no_call("Number of chains does not divide the number of draws.")
   }
   niterations <- ndraws %/% .nchains
   variables <- names(out)

--- a/R/as_draws_df.R
+++ b/R/as_draws_df.R
@@ -83,7 +83,7 @@ as_draws_df.draws_array <- function(x, ...) {
   rownames(x) <- NULL
   out <- named_list(chain_ids)
   for (i in seq_along(out)) {
-    out[[i]] <- drop2(x[, i, ], dims = 2, reset_class = TRUE)
+    out[[i]] <- drop_dims_or_classes(x[, i, ], dims = 2, reset_class = TRUE)
     class(out[[i]]) <- "matrix"
     out[[i]] <- tibble::as_tibble(out[[i]])
     out[[i]]$.chain <- chain_ids[i]
@@ -146,7 +146,7 @@ as_draws_df.mcmc.list <- function(x, ...) {
     .iteration <- as_one_character(.iteration)
     has_iteration_column <- .iteration %in% names(x)
     if (!has_iteration_column) {
-      stop2("Iteration indicator '", .iteration, "' cannot be found.")
+      stop_no_call("Iteration indicator '", .iteration, "' cannot be found.")
     }
   } else {
     .iteration <- ".iteration"
@@ -163,7 +163,7 @@ as_draws_df.mcmc.list <- function(x, ...) {
     .chain <- as_one_character(.chain)
     has_chain_column <- .chain %in% names(x)
     if (!has_chain_column) {
-      stop2("Chain indicator '", .chain, "' cannot be found.")
+      stop_no_call("Chain indicator '", .chain, "' cannot be found.")
     }
   } else {
     .chain <- ".chain"
@@ -197,11 +197,11 @@ draws_df <- function(..., .nchains = 1) {
   out <- validate_draws_per_variable(...)
   .nchains <- as_one_integer(.nchains)
   if (.nchains < 1) {
-    stop2("Number of chains must be positive.")
+    stop_no_call("Number of chains must be positive.")
   }
   ndraws <- length(out[[1]])
   if (ndraws %% .nchains != 0) {
-    stop2("Number of chains does not divide the number of draws.")
+    stop_no_call("Number of chains does not divide the number of draws.")
   }
   niterations <- ndraws %/% .nchains
   out <- as.data.frame(out, optional = TRUE)

--- a/R/as_draws_list.R
+++ b/R/as_draws_list.R
@@ -91,10 +91,10 @@ as_draws_list.mcmc.list <- function(x, ...) {
     x <- list(x)
   }
   if (any(!ulapply(x, is.list))) {
-    stop2("All list elements must be lists themselves.")
+    stop_no_call("All list elements must be lists themselves.")
   }
   if (length(unique(lengths(x))) != 1L) {
-    stop2("All list elements must have the same length.")
+    stop_no_call("All list elements must have the same length.")
   }
   if (is.null(names(x[[1]]))) {
     # no variable names provided; using default names
@@ -108,11 +108,11 @@ as_draws_list.mcmc.list <- function(x, ...) {
   niterations <- length(x[[1]][[1]])
   for (i in seq_along(x)) {
     if (!all(names(x[[i]]) == variables)) {
-      stop2("Variables in all chains must have the same names.")
+      stop_no_call("Variables in all chains must have the same names.")
     }
     for (j in seq_along(x[[i]])) {
       if (length(x[[i]][[j]]) != niterations) {
-        stop2("All variables in all chains must have the same length.")
+        stop_no_call("All variables in all chains must have the same length.")
       }
     }
   }

--- a/R/as_draws_rvars.R
+++ b/R/as_draws_rvars.R
@@ -198,7 +198,7 @@ draws_rvars <- function(..., .nchains = 1) {
   })
 
   if (!rlang::is_named(out)) {
-    stop2("All variables must be named.")
+    stop_no_call("All variables must be named.")
   }
 
   .as_draws_rvars(out)

--- a/R/bind_draws.R
+++ b/R/bind_draws.R
@@ -36,7 +36,7 @@ bind_draws.draws_matrix <- function(x, ..., along = "variable") {
     check_same_fun_output(dots, variables)
     out <- do.call(abind, c(dots, along = 1L))
   } else if (along == "chain") {
-    stop2("Cannot bind 'draws_matrix' objects along 'chain'.")
+    stop_no_call("Cannot bind 'draws_matrix' objects along 'chain'.")
   }
   as_draws_matrix(out)
 }
@@ -66,7 +66,7 @@ bind_draws.draws_array <- function(x, ..., along = "variable") {
     check_same_fun_output(dots, chain_ids)
     out <- do.call(abind, c(dots, along = 1L))
   } else if (along == "draw") {
-    stop2("Cannot bind 'draws_array' objects along 'draw'.")
+    stop_no_call("Cannot bind 'draws_array' objects along 'draw'.")
   }
   as_draws_array(out)
 }
@@ -157,7 +157,7 @@ bind_draws.draws_list <- function(x, ..., along = "variable") {
       }
     }
   } else if (along == "draw") {
-    stop2("Cannot bind 'draws_list' objects along 'draw'.")
+    stop_no_call("Cannot bind 'draws_list' objects along 'draw'.")
   }
   as_draws_list(out)
 }
@@ -180,7 +180,7 @@ bind_draws.draws_rvars <- function(x, ..., along = "variable") {
     check_same_fun_output(dots, iteration_ids)
     out <- do.call(c, dots)
   } else if (along == "iteration") {
-    stop2("Cannot bind 'draws_rvars' objects along 'iteration'.")
+    stop_no_call("Cannot bind 'draws_rvars' objects along 'iteration'.")
   } else if (along %in% c("chain", "draw")) {
     check_same_fun_output(dots, variables)
     if (along == "chain") {
@@ -208,7 +208,7 @@ bind_draws.NULL <- function(x, ..., along = "variable") {
   dots <- list(...)
   dots <- remove_null(dots)
   if (!length(dots)) {
-    stop2("All objects passed to 'bind_draws' are NULL.")
+    stop_no_call("All objects passed to 'bind_draws' are NULL.")
   }
   do.call(bind_draws, dots)
 }
@@ -220,14 +220,14 @@ bind_draws.NULL <- function(x, ..., along = "variable") {
 check_same_fun_output <- function(ls, fun) {
   assert_list(ls)
   if (is.function(fun)) {
-    fun_name <- deparse2(substitute(fun))
+    fun_name <- deparse_pretty(substitute(fun))
   } else {
     fun_name <- as_one_character(fun)
     fun <- get(fun, mode = "function")
   }
   ids <- lapply(ls, fun)
   if (sum(!duplicated(ids)) > 1L) {
-    stop2("'", fun_name, "' of bound objects do not match.")
+    stop_no_call("'", fun_name, "' of bound objects do not match.")
   }
   invisible(TRUE)
 }

--- a/R/convergence.R
+++ b/R/convergence.R
@@ -139,7 +139,7 @@ ess_tail <- function(x) {
 ess_quantile <- function(x, probs = c(0.05, 0.95), names = TRUE) {
   probs <- as.numeric(probs)
   if (any(probs < 0 | probs > 1)) {
-    stop2("'probs' must contain values between 0 and 1.")
+    stop_no_call("'probs' must contain values between 0 and 1.")
   }
   names <- as_one_logical(names)
   out <- ulapply(probs, .ess_quantile, x = x)
@@ -222,7 +222,7 @@ ess_sd <- function(x) {
 mcse_quantile <- function(x, probs = c(0.05, 0.95), names = TRUE) {
   probs <- as.numeric(probs)
   if (any(probs < 0 | probs > 1)) {
-    stop2("'probs' must contain values between 0 and 1.")
+    stop_no_call("'probs' must contain values between 0 and 1.")
   }
   names <- as_one_logical(names)
   out <- ulapply(probs, .mcse_quantile, x = x)

--- a/R/draws-index.R
+++ b/R/draws-index.R
@@ -449,7 +449,7 @@ check_existing_variables <- function(variables, x, regex = FALSE,
   }
   variables <- check_reserved_variables(variables)
   if (length(missing_variables)) {
-    stop2("The following variables are missing in the draws object: ",
+    stop_no_call("The following variables are missing in the draws object: ",
           comma(missing_variables))
   }
   variables
@@ -463,7 +463,7 @@ check_new_variables <- function(variables) {
   # we shouldn't expect to take this branch often (since it is an error)
   if (anyDuplicated(variables)) {
     duplicates = unique(variables[duplicated(variables)])
-    stop2(
+    stop_no_call(
       "Duplicate variable names are not allowed in draws objects.\n",
       "The following variable names are duplicates:\n",
       comma(duplicates)
@@ -480,7 +480,7 @@ check_reserved_variables <- function(variables) {
   # this has the advantage that power users can directly add such variables
   used_reserved_variables <- intersect(reserved_df_variables(), variables)
   if (length(used_reserved_variables)) {
-    stop2("Variable names ", comma(used_reserved_variables), " are reserved.")
+    stop_no_call("Variable names ", comma(used_reserved_variables), " are reserved.")
   }
   variables
 }
@@ -499,12 +499,12 @@ check_iteration_ids <- function(iteration_ids, x, unique = TRUE) {
   }
   iteration_ids <- sort(iteration_ids)
   if (any(iteration_ids < 1L)) {
-    stop2("Iteration indices should be positive.")
+    stop_no_call("Iteration indices should be positive.")
   }
   niterations <- niterations(x)
   max_iteration <- SW(max(iteration_ids))
   if (max_iteration > niterations) {
-    stop2("Tried to subset iterations up to '", max_iteration, "' ",
+    stop_no_call("Tried to subset iterations up to '", max_iteration, "' ",
           "but the object only has '", niterations, "' iterations.")
   }
   iteration_ids
@@ -524,12 +524,12 @@ check_chain_ids <- function(chain_ids, x, unique = TRUE) {
   }
   chain_ids <- sort(chain_ids)
   if (any(chain_ids < 1L)) {
-    stop2("Chain indices should be positive.")
+    stop_no_call("Chain indices should be positive.")
   }
   nchains <- nchains(x)
   max_chain <- SW(max(chain_ids))
   if (max_chain > nchains) {
-    stop2("Tried to subset chains up to '", max_chain, "' ",
+    stop_no_call("Tried to subset chains up to '", max_chain, "' ",
           "but the object only has '", nchains, "' chains.")
   }
   chain_ids
@@ -549,12 +549,12 @@ check_draw_ids <- function(draw_ids, x, unique = TRUE) {
   }
   draw_ids <- sort(draw_ids)
   if (any(draw_ids < 1L)) {
-    stop2("Draw indices should be positive.")
+    stop_no_call("Draw indices should be positive.")
   }
   ndraws <- ndraws(x)
   max_draw <- SW(max(draw_ids))
   if (max_draw > ndraws) {
-    stop2("Tried to subset draws up to '", max_draw, "' ",
+    stop_no_call("Tried to subset draws up to '", max_draw, "' ",
           "but the object only has '", ndraws, "' draws.")
   }
   draw_ids

--- a/R/extract_variable.R
+++ b/R/extract_variable.R
@@ -45,7 +45,7 @@ extract_variable.draws_rvars <- function(x, variable, ...) {
     root_variable <- regmatches(variable, variable_regex)[[1]][[2]]
     out <- extract_variable(as_draws_array(x[root_variable]), variable, ...)
   } else if (length(x[[variable]]) > 1) {
-    stop2(
+    stop_no_call(
       'Cannot extract non-scalar value using extract_variable():\n',
       '  "', variable, '" has dimensions: [', paste0(dim(x[[variable]]), collapse = ","), ']\n',
       '  Try including brackets ("[]") and indices in the variable name to extract a scalar value.'

--- a/R/extract_variable_matrix.R
+++ b/R/extract_variable_matrix.R
@@ -32,7 +32,7 @@ extract_variable_matrix.draws <- function(x, variable, ...) {
   variable <- as_one_character(variable)
   out <- .subset_draws(x, variable = variable, reserved = FALSE)
   out <- as_draws_array(out)
-  out <- drop2(out, dims = 3, reset_class = TRUE)
+  out <- drop_dims_or_classes(out, dims = 3, reset_class = TRUE)
   class(out) <- "matrix"
   out
 }
@@ -49,7 +49,7 @@ extract_variable_matrix.draws_rvars <- function(x, variable, ...) {
     root_variable <- regmatches(variable, variable_regex)[[1]][[2]]
     extract_variable_matrix(as_draws_array(x[root_variable]), variable, ...)
   } else if (length(x[[variable]]) > 1) {
-    stop2(
+    stop_no_call(
       'Cannot extract non-scalar value using extract_variable_matrix():\n',
       '  "', variable, '" has dimensions: [', paste0(dim(x[[variable]]), collapse = ","), ']\n',
       '  Try including brackets ("[]") and indices in the variable name to extract a scalar value.'

--- a/R/misc.R
+++ b/R/misc.R
@@ -28,7 +28,7 @@ seq_cols <- function(x) {
 }
 
 # selectively drop one-level dimensions of an array and/or reset object classes
-drop2 <- function(x, dims = NULL, reset_class = FALSE) {
+drop_dims_or_classes <- function(x, dims = NULL, reset_class = FALSE) {
   assert_array(x)
   assert_integerish(dims, null.ok = TRUE)
   reset_class <- as_one_logical(reset_class)
@@ -51,7 +51,7 @@ drop2 <- function(x, dims = NULL, reset_class = FALSE) {
     }
   }
   # optionally, set class to NULL and let R decide appropriate classes
-  if(reset_class) {
+  if (reset_class) {
     class(x) <- NULL
   }
   x
@@ -72,8 +72,8 @@ as_one_logical <- function(x, allow_na = FALSE) {
   s <- substitute(x)
   x <- as.logical(x)
   if (length(x) != 1L || anyNA(x) && !allow_na) {
-    s <- deparse2(s)
-    stop2("Cannot coerce '", s, "' to a single logical value.")
+    s <- deparse_pretty(s)
+    stop_no_call("Cannot coerce '", s, "' to a single logical value.")
   }
   x
 }
@@ -83,8 +83,8 @@ as_one_integer <- function(x, allow_na = FALSE) {
   s <- substitute(x)
   x <- SW(as.integer(x))
   if (length(x) != 1L || anyNA(x) && !allow_na) {
-    s <- deparse2(s)
-    stop2("Cannot coerce '", s, "' to a single integer value.")
+    s <- deparse_pretty(s)
+    stop_no_call("Cannot coerce '", s, "' to a single integer value.")
   }
   x
 }
@@ -94,8 +94,8 @@ as_one_numeric <- function(x, allow_na = FALSE) {
   s <- substitute(x)
   x <- SW(as.numeric(x))
   if (length(x) != 1L || anyNA(x) && !allow_na) {
-    s <- deparse2(s)
-    stop2("Cannot coerce '", s, "' to a single numeric value.")
+    s <- deparse_pretty(s)
+    stop_no_call("Cannot coerce '", s, "' to a single numeric value.")
   }
   x
 }
@@ -105,8 +105,8 @@ as_one_character <- function(x, allow_na = FALSE) {
   s <- substitute(x)
   x <- as.character(x)
   if (length(x) != 1L || anyNA(x) && !allow_na) {
-    s <- deparse2(s)
-    stop2("Cannot coerce '", s, "' to a single character value.")
+    s <- deparse_pretty(s)
+    stop_no_call("Cannot coerce '", s, "' to a single character value.")
   }
   x
 }
@@ -131,7 +131,7 @@ move_to_start <- function(x, start) {
 
 # prettily deparse an expression
 # @return a single character string
-deparse2 <- function(x, max_chars = NULL, max_wsp = 1L) {
+deparse_pretty <- function(x, max_chars = NULL, max_wsp = 1L) {
   out <- collapse(deparse(x))
   out <- rm_wsp(out, max_wsp)
   assert_int(max_chars, null.ok = TRUE)
@@ -185,7 +185,7 @@ comma <- function(...) {
   paste0("{", paste0("'", c(...), "'", collapse = ", "), "}")
 }
 
-stop2 <- function(...) {
+stop_no_call <- function(...) {
   stop(..., call. = FALSE)
 }
 

--- a/R/mutate_variables.R
+++ b/R/mutate_variables.R
@@ -93,14 +93,14 @@ mutate_variables.draws_rvars <- function(.x, ...) {
 .mutate_variable <- function(expr, data, env = caller_env()) {
   out <- eval_tidy(expr, data, env)
   if (!is.numeric(out)) {
-    stop2("{", as_label(expr), "} does not evaluate to a numeric vector.")
+    stop_no_call("{", as_label(expr), "} does not evaluate to a numeric vector.")
   }
   n <- length(data[[1]])
   if (length(out) == 1L) {
     out <- rep(out, n)
   }
   if (length(out) != n) {
-    stop2("{", as_label(expr), "} does not evaluate ",
+    stop_no_call("{", as_label(expr), "} does not evaluate ",
           "to a vector of length 1 or ", n, ".")
   }
   out

--- a/R/rename_variables.R
+++ b/R/rename_variables.R
@@ -40,7 +40,7 @@ rename_variables.draws <- function(.x, ...) {
 
   if (any(new_names == "")) {
     old_names_without_new_name = old_names[new_names == ""]
-    stop2(
+    stop_no_call(
       "Cannot rename a variable to an empty name.\n",
       "The following variables did not have a new name provided:\n",
       comma(old_names_without_new_name)

--- a/R/resample_draws.R
+++ b/R/resample_draws.R
@@ -65,7 +65,7 @@ resample_draws.draws <- function(x, weights = NULL, method = "stratified",
   if (is.null(weights)) {
     weights <- weights(x, normalize = TRUE)
     if (is.null(weights)) {
-      stop2("No weights are provided and none can ",
+      stop_no_call("No weights are provided and none can ",
             "be found within the draws object.")
     }
     # resampling invalidates stored weights
@@ -75,7 +75,7 @@ resample_draws.draws <- function(x, weights = NULL, method = "stratified",
   }
   if (is.null(ndraws)) {
     if (grepl("_no_replace$", method)) {
-      stop2("Argument 'ndraws' is required when sampling without replacement.")
+      stop_no_call("Argument 'ndraws' is required when sampling without replacement.")
     }
     ndraws <- length(weights)
   }
@@ -96,7 +96,7 @@ resample_draws.draws <- function(x, weights = NULL, method = "stratified",
 # @return index vector of length 'ndraws'
 .resample_simple_no_replace <- function(weights, ndraws, ...) {
   if (ndraws > length(weights)) {
-    stop2("Argument 'ndraws' must be smaller than the total ",
+    stop_no_call("Argument 'ndraws' must be smaller than the total ",
           "number of draws in method 'simple_no_replace'.")
   }
   out <- seq_along(weights)

--- a/R/rstar.R
+++ b/R/rstar.R
@@ -93,7 +93,7 @@ rstar <- function(x, split = TRUE,
                   ...) {
 
   if (!"caret" %in% .packages()) {
-    stop2("Package 'caret' is required for 'rstar' to work. ",
+    stop_no_call("Package 'caret' is required for 'rstar' to work. ",
           "Please use library(caret) to load the package.")
   }
 
@@ -102,11 +102,11 @@ rstar <- function(x, split = TRUE,
   method <- as_one_character(method)
   nsimulations <- as_one_integer(nsimulations)
   if (nsimulations < 1) {
-    stop2("'nsimulations' must be greater than or equal to 1.")
+    stop_no_call("'nsimulations' must be greater than or equal to 1.")
   }
   training_proportion <- as_one_numeric(training_proportion)
   if (training_proportion <= 0 || training_proportion >= 1) {
-    stop2("'training_proportion' must be greater than 0 and less than 1.")
+    stop_no_call("'training_proportion' must be greater than 0 and less than 1.")
   }
 
   # caret requires data.frame like objects
@@ -132,7 +132,7 @@ rstar <- function(x, split = TRUE,
     )
   } else {
     if (!(is.null(hyperparameters) || is.list(hyperparameters))) {
-      stop2("'hyperparameters' must be a list or NULL.")
+      stop_no_call("'hyperparameters' must be a list or NULL.")
     }
     caret_grid <- hyperparameters
   }

--- a/R/rvar-.R
+++ b/R/rvar-.R
@@ -221,7 +221,7 @@ anyDuplicated.rvar <- function(x, incomparables = FALSE, MARGIN = 1, ...) {
 # then return the corresponding margin for draws_of(x)
 check_rvar_margin <- function(x, MARGIN) {
   if (!(1 <= MARGIN && MARGIN <= length(dim(x)))) {
-    stop2("MARGIN = ", MARGIN, " is invalid for dim = ", paste0(dim(x), collapse = ","))
+    stop_no_call("MARGIN = ", MARGIN, " is invalid for dim = ", paste0(dim(x), collapse = ","))
   }
   MARGIN + 1
 }
@@ -253,13 +253,13 @@ check_rvar_yank_index = function(x, i, ...) {
   index <- dots_list(i, ..., .preserve_empty = TRUE, .ignore_empty = "none")
 
   if (any(lengths(index)) > 1) {
-    stop2("Cannot select more than one element per index with `[[` in an rvar.")
+    stop_no_call("Cannot select more than one element per index with `[[` in an rvar.")
   } else if (any(sapply(index, function(x) is_missing(x) || is.na(x)))) {
-    stop2("Missing indices not allowed with `[[` in an rvar.")
+    stop_no_call("Missing indices not allowed with `[[` in an rvar.")
   } else if (any(sapply(index, is.logical))) {
-    stop2("Logical indices not allowed with `[[` in an rvar.")
+    stop_no_call("Logical indices not allowed with `[[` in an rvar.")
   } else if (any(sapply(index, function(x) x < 0))) {
-    stop2("subscript out of bounds")
+    stop_no_call("subscript out of bounds")
   }
 
   index
@@ -270,7 +270,7 @@ check_rvar_yank_index = function(x, i, ...) {
 check_rvar_subset_indices = function(x, ...) {
   ndim = max(length(dim(x)), 1)
   if (length(substitute(list(...))) - 1 > ndim) {
-    stop2("Cannot index past dimension ", ndim, ".")
+    stop_no_call("Cannot index past dimension ", ndim, ".")
   }
 }
 
@@ -283,7 +283,7 @@ ndraws2_common <- function(ndraws_x, ndraws_y) {
   } else if (ndraws_x == ndraws_y) {
     ndraws_x
   } else {
-    stop2(
+    stop_no_call(
       "Random variables have different number of draws (", ndraws_x,
       " and ", ndraws_y, ") and cannot be used together."
     )
@@ -317,10 +317,10 @@ nchains2_common <- function(nchains_x, nchains_y) {
 check_nchains_compat_with_ndraws <- function(nchains, ndraws) {
   # except with constants, nchains must divide the number of draws
   if (ndraws != 1 && isTRUE(ndraws %% nchains != 0)) {
-    stop2("Number of chains does not divide the number of draws.")
+    stop_no_call("Number of chains does not divide the number of draws.")
   }
   if (nchains < 1) {
-    stop2("Number of chains must be >= 1")
+    stop_no_call("Number of chains must be >= 1")
   }
 }
 
@@ -368,7 +368,7 @@ check_rvar_dims_first <- function(x, y) {
   } else if (identical(x_dim_dropped, y_dim_dropped)) {
     dim(x) <- dim(y)
   } else {
-    stop2("Cannot assign an rvar with dimension ", paste0(x_dim, collapse = ","),
+    stop_no_call("Cannot assign an rvar with dimension ", paste0(x_dim, collapse = ","),
       " to an rvar with dimension ", paste0(y_dim, collapse = ","))
   }
 
@@ -415,7 +415,7 @@ broadcast_array  <- function(x, dim, broadcast_scalars = TRUE) {
     current_dim[seq(length(current_dim) + 1, length(dim))] = 1
     dim(x) = current_dim
   } else if (length(current_dim) > length(dim)) {
-    stop2(
+    stop_no_call(
       "Cannot broadcast array of shape [", paste(current_dim, collapse = ","), "] ",
       "to array of shape [", paste(dim, collapse = ","), "]:\n",
       "Desired shape has fewer dimensions than existing array."
@@ -430,7 +430,7 @@ broadcast_array  <- function(x, dim, broadcast_scalars = TRUE) {
   }
 
   if (any(current_dim[dim_to_broadcast] != 1)) {
-    stop2(
+    stop_no_call(
       "Cannot broadcast array of shape [", paste(current_dim, collapse = ","), "] ",
       "to array of shape [", paste(dim, collapse = ","), "]:\n",
       "All dimensions must be 1 or equal."

--- a/R/rvar-dist.R
+++ b/R/rvar-dist.R
@@ -21,7 +21,7 @@
 #' @export
 density.rvar <- function(x, at, ...) {
   if (length(x) != 1) {
-    stop2("density() can currently only be used on scalar rvars")
+    stop_no_call("density() can currently only be used on scalar rvars")
   }
 
   d <- density(draws_of(x), cut = 0, ...)
@@ -37,7 +37,7 @@ distributional::cdf
 #' @export
 cdf.rvar <- function(x, q, ...) {
   if (length(x) != 1) {
-    stop2("cdf() can currently only be used on scalar rvars")
+    stop_no_call("cdf() can currently only be used on scalar rvars")
   }
 
   ecdf(draws_of(x))(q)

--- a/R/rvar-math.R
+++ b/R/rvar-math.R
@@ -57,7 +57,7 @@ Pr <- function(x, ...) UseMethod("Pr")
 #' @rdname rvar-summaries
 #' @export
 Pr.default <- function(x, ...) {
-  stop2("Can only use `Pr()` on logical variables.")
+  stop_no_call("Can only use `Pr()` on logical variables.")
 }
 
 #' @rdname rvar-summaries
@@ -70,7 +70,7 @@ Pr.logical <- function(x, ...) {
 #' @export
 Pr.rvar <- function(x, ...) {
   if (!is.logical(draws_of(x))) {
-    stop2("Can only use `Pr()` on logical random variables.")
+    stop_no_call("Can only use `Pr()` on logical random variables.")
   }
   mean(x, ...)
 }
@@ -286,14 +286,14 @@ Math.rvar <- function(x, ...) {
   if (ndim_x == 1) {
     dim(x) <- c(1, dim(x))
   } else if (ndim_x != 2) {
-    stop2("First argument (`x`) is not a vector or matrix, cannot matrix-multiply")
+    stop_no_call("First argument (`x`) is not a vector or matrix, cannot matrix-multiply")
   }
 
   ndim_y <- length(dim(y))
   if (ndim_y == 1) {
     dim(y) <- c(dim(y), 1)
   } else if (ndim_y != 2) {
-    stop2("Second argument (`y`) is not a vector or matrix, cannot matrix-multiply")
+    stop_no_call("Second argument (`y`) is not a vector or matrix, cannot matrix-multiply")
   }
 
   # convert both objects into rvars if they aren't already (this will give us
@@ -340,7 +340,7 @@ Math.rvar <- function(x, ...) {
 chol.rvar <- function(x, ...) {
   # ensure x is a matrix
   if (length(dim(x)) != 2) {
-    stop2("`x` must be a random matrix")
+    stop_no_call("`x` must be a random matrix")
   }
 
   # must re-order draws dimension to the end, as chol.tensor expects it there
@@ -375,7 +375,7 @@ t.rvar = function(x) {
     .draws <- aperm(.draws, c(1, 3, 2))
     result <- new_rvar(.draws, .nchains = nchains(x))
   } else {
-    stop2("argument is not a random vector or matrix")
+    stop_no_call("argument is not a random vector or matrix")
   }
   result
 }

--- a/R/rvar-print.R
+++ b/R/rvar-print.R
@@ -177,6 +177,6 @@ get_summary_functions <- function(summary = NULL) {
   switch(summary,
     mean_sd = c("mean", "sd"),
     median_mad = c("median", "mad"),
-    stop2('`summary` must be one of "mean_sd" or "median_mad"')
+    stop_no_call('`summary` must be one of "mean_sd" or "median_mad"')
   )
 }

--- a/R/rvar-rfun.R
+++ b/R/rvar-rfun.R
@@ -56,12 +56,12 @@ rfun <- function (.f, rvar_args = NULL, ndraws = NULL) {
   rvar_args <- as.character(rvar_args %||% arg_names)
 
   if (!all(rvar_args %in% arg_names)) {
-    stop2("must specify names of formal arguments for 'rfun'")
+    stop_no_call("must specify names of formal arguments for 'rfun'")
   }
 
   collisions <- arg_names %in% c("FUN", "SIMPLIFY", "USE.NAMES")
   if (any(collisions)) {
-    stop2("'.f' may not have argument(s) named ", comma(arg_names[collisions]))
+    stop_no_call("'.f' may not have argument(s) named ", comma(arg_names[collisions]))
   }
 
   FUNV <- function() {
@@ -236,7 +236,7 @@ rvar_rng <- function(.f, n, ..., ndraws = NULL) {
 
     rvar_args_ndims <- lengths(lapply(rvar_args, dim))
     if (!all(rvar_args_ndims == 1)) {
-      stop2("All arguments to rvar_rng() that are rvars must be single-dimensional (vectors).")
+      stop_no_call("All arguments to rvar_rng() that are rvars must be single-dimensional (vectors).")
     }
 
     args[is_rvar_arg] <- lapply(rvar_args, function(x) t(draws_of(x)))

--- a/R/rvar-slice.R
+++ b/R/rvar-slice.R
@@ -21,7 +21,7 @@
     dim(.draws) <- c(ndraws(x), 1)
     out <- new_rvar(.draws, .nchains = nchains(x))
   } else {
-    stop2("subscript out of bounds")
+    stop_no_call("subscript out of bounds")
   }
   out
 }
@@ -60,7 +60,7 @@
       x
     }))
   } else {
-    stop2("subscript out of bounds")
+    stop_no_call("subscript out of bounds")
   }
   x
 }

--- a/R/subset_draws.R
+++ b/R/subset_draws.R
@@ -164,7 +164,7 @@ subset_dims <- function(x, ...) {
   }
   dim_x <- max(length(dim(x)), 1L)
   if (length(dots) > dim_x) {
-    stop2("'x' has only ", dim_x, " dimensions.")
+    stop_no_call("'x' has only ", dim_x, " dimensions.")
   }
   if (length(dots) < dim_x) {
     dots <- c(dots, repl(NULL, dim_x - length(dots)))
@@ -331,10 +331,10 @@ prepare_subsetting <- function(x, iteration = NULL, chain = NULL,
                                draw = NULL) {
   if (!is.null(draw)) {
     if (!is.null(iteration)) {
-      stop2("Cannot subset 'iteration' and 'draw' at the same time.")
+      stop_no_call("Cannot subset 'iteration' and 'draw' at the same time.")
     }
     if (!is.null(chain)) {
-      stop2("Cannot subset 'chain' and 'draw' at the same time.")
+      stop_no_call("Cannot subset 'chain' and 'draw' at the same time.")
     }
     if (nchains(x) > 1L) {
       message("Merging chains in order to subset via 'draw'.")

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -76,7 +76,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
       names(funs) <- rep("", length(funs))
     }
     calls <- substitute(list(...))[-1]
-    calls <- ulapply(calls, deparse2)
+    calls <- ulapply(calls, deparse_pretty)
     for (i in seq_along(funs)) {
       fname <- NULL
       if (is.character(funs[[i]])) {
@@ -97,7 +97,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
         } else if (fname %in% getNamespaceExports("posterior")) {
           env <- asNamespace("posterior")
         } else {
-          stop2("Cannot find function '", fname, "'.")
+          stop_no_call("Cannot find function '", fname, "'.")
         }
       }
       funs[[i]] <- rlang::as_function(funs[[i]], env = env)
@@ -126,7 +126,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   variables <- variables(x)
   out <- named_list(variables, values = list(named_list(names(funs))))
   for (v in variables) {
-    draws <- drop2(x[, , v], dims = 3, reset_class = TRUE)
+    draws <- drop_dims_or_classes(x[, , v], dims = 3, reset_class = TRUE)
     args <- c(list(draws), .args)
     for (m in names(funs)) {
       out[[v]][[m]] <- do.call(funs[[m]], args)
@@ -139,7 +139,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   }
   out <- tibble::as_tibble(do.call(rbind, out))
   if ("variable" %in% names(out)) {
-    stop2("Name 'variable' is reserved in 'summarise_draws'.")
+    stop_no_call("Name 'variable' is reserved in 'summarise_draws'.")
   }
   out$variable <- variables
   out <- move_to_start(out, "variable")
@@ -157,7 +157,7 @@ summary.draws <- function(object, ...) {
 #' @export
 summarise_draws.rvar <- function(x, ...) {
   .x <- draws_rvars(x = x)
-  names(.x) <- deparse2(substitute(x))
+  names(.x) <- deparse_pretty(substitute(x))
   summarise_draws(.x, ...)
 }
 
@@ -165,7 +165,7 @@ summarise_draws.rvar <- function(x, ...) {
 #' @export
 summary.rvar <- function(object, ...) {
   .x <- draws_rvars(x = object)
-  names(.x) <- deparse2(substitute(object))
+  names(.x) <- deparse_pretty(substitute(object))
   summarise_draws(.x, ...)
 }
 

--- a/R/thin_draws.R
+++ b/R/thin_draws.R
@@ -30,11 +30,11 @@ thin_draws.draws <- function(x, thin, ...) {
     return(x)
   }
   if (thin <= 0L) {
-    stop2("'thin' must be a positive integer.")
+    stop_no_call("'thin' must be a positive integer.")
   }
   niterations <- niterations(x)
   if (thin > niterations ) {
-    stop2("'thin' must be smaller than the total number of iterations.")
+    stop_no_call("'thin' must be smaller than the total number of iterations.")
   }
   iteration_ids <- seq(1, niterations, by = thin)
   subset_draws(x, iteration = iteration_ids)

--- a/R/weight_draws.R
+++ b/R/weight_draws.R
@@ -152,11 +152,11 @@ validate_weights <- function(weights, draws, log = FALSE) {
   checkmate::expect_numeric(weights)
   checkmate::expect_flag(log)
   if (length(weights) != ndraws(draws)) {
-    stop2("Number of weights must match the number of draws.")
+    stop_no_call("Number of weights must match the number of draws.")
   }
   if (!log) {
     if (any(weights < 0)) {
-      stop2("Weights must be non-negative.")
+      stop_no_call("Weights must be non-negative.")
     }
     weights <- log(weights)
   }


### PR DESCRIPTION
I think it will make our source code easier to read if function names indicate their purpose as much as possible. Most of our function names already do this well, but this PR changes a few that don't: 

`deparse2` -> `deparse_pretty` 
`drop2` -> `drop_dims_or_classes`
`stop2` -> `stop_no_call` 

I'm not attached to these particular new names so I'm happy to change them if anyone has suggestions, but I think these names at least hint at the reason for the existence of the functions. 
