### PR TITLE
Improve summarise_draws efficiency

### DIFF
--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -127,7 +127,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
 
   # get length and output names, calculated on the first variable
   v1 <- variables[1]
-  draws1 <- drop_dims_or_classes(x[, , v1], dims = 3)
+  draws1 <- drop_dims_or_classes(x[, , v1], dims = 3, reset_class = FALSE)
   args1 <- c(list(draws1), .args)
   out1 <- named_list(names(funs))
   n_fun <- length(out1)

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -133,16 +133,17 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   for (m in names(funs)) {
     out1[[m]] <- do.call(funs[[m]], args1)
   }
-  the_names <- vector()
+  the_names <- vector(mode = "list", length = length(out1))
   for (i in 1:length(out1)){
     if (rlang::is_named(out1[[i]])) {
-      the_names <- c(the_names, names(out1[[i]]))
+      the_names[[i]] <- names(out1[[i]])
     } else if (length(out1[[i]]) > 1) {
-      the_names <- c(the_names, paste0(names(out1)[i], ".", c(1:length(out1[[i]]))))
+      the_names[[i]] <- paste0(names(out1)[i], ".", c(1:length(out1[[i]])))
     } else {
-      the_names <- c(the_names, names(out1)[i])
+      the_names[[i]] <- names(out1)[i]
     }
   }
+  the_names <- unlist(the_names)
   
   # Check for naming issues prior do doing lengthy computation
   if ("variable" %in% the_names) {

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -68,7 +68,6 @@ summarise_draws.default <- function(x, ...) {
 #' @rdname draws_summary
 #' @export
 summarise_draws.draws <- function(x, ..., .args = list()) {
-  print("new version")
   funs <- as.list(c(...))
   .args <- as.list(.args)
   if (length(funs)) {

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -152,7 +152,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   }
   
   # Pre-allocate matrix to store output
-  out <- matrix(NA, nrow = length(variables), ncol = length(unlist(out1)))
+  out <- matrix(NA, nrow = length(variables), ncol = length(the_names))
   colnames(out) <- the_names
   out[1, ] <- unlist(out1)
   

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -130,11 +130,12 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   draws1 <- drop_dims_or_classes(x[, , v1], dims = 3)
   args1 <- c(list(draws1), .args)
   out1 <- named_list(names(funs))
+  n_fun <- length(out1)
   for (m in names(funs)) {
     out1[[m]] <- do.call(funs[[m]], args1)
   }
-  the_names <- vector(mode = "list", length = length(out1))
-  for (i in 1:length(out1)){
+  the_names <- vector(mode = "list", length = n_fun)
+  for (i in 1:n_fun){
     if (rlang::is_named(out1[[i]])) {
       the_names[[i]] <- names(out1[[i]])
     } else if (length(out1[[i]]) > 1) {

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -126,7 +126,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   variables <- variables(x)
   
   if (length(variables)) {
-    get_summary_list <- function(x, v) {
+  create_summary_list <- function(x, v) {
       draws <- drop_dims_or_classes(x[, , v], dims = 3, reset_class = FALSE)
       args <- c(list(draws), .args)
       v_summary <- named_list(names(funs))

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -169,8 +169,10 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
     class(out) <- class_draws_summary()
     return(out)
   } else { # i.e. if length(variables) == 0L
-    warning("the draws object contained no variables with unreserved names; 
-            no summaries computed")
+    warning_no_call(
+      "The draws object contained no variables with unreserved names. ",
+      "No summaries were computed."
+    )
     return(tibble::tibble(character()))
   }
 }

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -68,6 +68,7 @@ summarise_draws.default <- function(x, ...) {
 #' @rdname draws_summary
 #' @export
 summarise_draws.draws <- function(x, ..., .args = list()) {
+  print("new version")
   funs <- as.list(c(...))
   .args <- as.list(.args)
   if (length(funs)) {

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -161,7 +161,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
       args <- c(list(draws), .args)
       out_v <- named_list(names(funs))
       for (m in names(funs)) {
-        out_v[[m]] <- do.call(funs[[m]], args1)
+        out_v[[m]] <- do.call(funs[[m]], args)
       }
       out[v_ind, ] <- unlist(out_v)
     }

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -159,7 +159,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
     # Do the computation for all remaining variables
     if (length(variables) > 1L) {
       for (v_ind in 2:length(variables)) {
-        out_v <- get_summary_list(x, variables[v_ind])
+        out_v <- create_summary_list(x, variables[v_ind])
         out[v_ind, ] <- unlist(out_v)
       }
     }

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -159,8 +159,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
     # Do the computation for all remaining variables
     if (length(variables) > 1L) {
       for (v_ind in 2:length(variables)) {
-        v <- variables[v_ind]
-        out_v <- get_summary_list(x, v)
+        out_v <- get_summary_list(x, variables[v_ind])
         out[v_ind, ] <- unlist(out_v)
       }
     }

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -159,7 +159,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
       v <- variables[v_ind]
       draws <- drop_dims(x[, , v], dims = 3)
       args <- c(list(draws), .args)
-      out_v <- named_list(names(funs))
+      out_v <- vector(mode = "list", length = length(funs))
       for (m in names(funs)) {
         out_v[[m]] <- do.call(funs[[m]], args)
       }

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -136,7 +136,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
       return(v_summary)
     }
     # get length and output names, calculated on the first variable
-    out1 <- get_summary_list(x, variables[1])
+    out1 <- create_summary_list(x, variables[1])
     the_names <- vector(mode = "list", length = length(funs))
     for (i in seq_along(out1)){
       if (rlang::is_named(out1[[i]])) {

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -126,8 +126,6 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   variables <- variables(x)
   
   if (length(variables)) {
-    n_fun <- length(funs)
-    
     get_summary_list <- function(x, v) {
       draws <- drop_dims_or_classes(x[, , v], dims = 3, reset_class = FALSE)
       args <- c(list(draws), .args)
@@ -137,11 +135,10 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
       }
       return(v_summary)
     }
-    
     # get length and output names, calculated on the first variable
     out1 <- get_summary_list(x, variables[1])
-    the_names <- vector(mode = "list", length = n_fun)
-    for (i in 1:n_fun){
+    the_names <- vector(mode = "list", length = length(funs))
+    for (i in seq_along(out1)){
       if (rlang::is_named(out1[[i]])) {
         the_names[[i]] <- names(out1[[i]])
       } else if (length(out1[[i]]) > 1) {
@@ -151,17 +148,14 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
       }
     }
     the_names <- unlist(the_names)
-    
     # Check for naming issues prior do doing lengthy computation
     if ("variable" %in% the_names) {
       stop_no_call("Name 'variable' is reserved in 'summarise_draws'.")
     }
-    
     # Pre-allocate matrix to store output
     out <- matrix(NA, nrow = length(variables), ncol = length(the_names))
     colnames(out) <- the_names
     out[1, ] <- unlist(out1)
-    
     # Do the computation for all remaining variables
     if (length(variables) > 1L) {
       for (v_ind in 2:length(variables)) {
@@ -170,13 +164,12 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
         out[v_ind, ] <- unlist(out_v)
       }
     }
-    
     out <- tibble::as_tibble(out)
     out$variable <- variables
     out <- move_to_start(out, "variable")
     class(out) <- class_draws_summary()
     return(out)
-  } else {
+  } else { # i.e. if length(variables) == 0L
     warning("the draws object contained no variables with unreserved names; 
             no summaries computed")
     return(tibble::tibble(character()))

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -127,7 +127,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   variables <- variables(x)
   # get length and output names, calculated on the first variable
   v1 <- variables[1]
-  draws1 <- drop_dims(x[, , v], dims = 3)
+  draws1 <- drop_dims(x[, , v1], dims = 3)
   args1 <- c(list(draws1), .args)
   out1 <- named_list(names(funs))
   for (m in names(funs)) {

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -125,56 +125,56 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   x <- as_draws_array(x)
   variables <- variables(x)
   
-  if (length(variables)) {
-  create_summary_list <- function(x, v) {
-      draws <- drop_dims_or_classes(x[, , v], dims = 3, reset_class = FALSE)
-      args <- c(list(draws), .args)
-      v_summary <- named_list(names(funs))
-      for (m in names(funs)) {
-        v_summary[[m]] <- do.call(funs[[m]], args)
-      }
-      return(v_summary)
-    }
-    # get length and output names, calculated on the first variable
-    out1 <- create_summary_list(x, variables[1])
-    the_names <- vector(mode = "list", length = length(funs))
-    for (i in seq_along(out1)){
-      if (rlang::is_named(out1[[i]])) {
-        the_names[[i]] <- names(out1[[i]])
-      } else if (length(out1[[i]]) > 1) {
-        the_names[[i]] <- paste0(names(out1)[i], ".", c(1:length(out1[[i]])))
-      } else {
-        the_names[[i]] <- names(out1)[i]
-      }
-    }
-    the_names <- unlist(the_names)
-    # Check for naming issues prior do doing lengthy computation
-    if ("variable" %in% the_names) {
-      stop_no_call("Name 'variable' is reserved in 'summarise_draws'.")
-    }
-    # Pre-allocate matrix to store output
-    out <- matrix(NA, nrow = length(variables), ncol = length(the_names))
-    colnames(out) <- the_names
-    out[1, ] <- unlist(out1)
-    # Do the computation for all remaining variables
-    if (length(variables) > 1L) {
-      for (v_ind in 2:length(variables)) {
-        out_v <- create_summary_list(x, variables[v_ind])
-        out[v_ind, ] <- unlist(out_v)
-      }
-    }
-    out <- tibble::as_tibble(out)
-    out$variable <- variables
-    out <- move_to_start(out, "variable")
-    class(out) <- class_draws_summary()
-    return(out)
-  } else { # i.e. if length(variables) == 0L
+  if (!length(variables)) {
     warning_no_call(
       "The draws object contained no variables with unreserved names. ",
       "No summaries were computed."
     )
     return(tibble::tibble(character()))
   }
+  
+  create_summary_list <- function(x, v) {
+    draws <- drop_dims_or_classes(x[, , v], dims = 3, reset_class = FALSE)
+    args <- c(list(draws), .args)
+    v_summary <- named_list(names(funs))
+    for (m in names(funs)) {
+      v_summary[[m]] <- do.call(funs[[m]], args)
+    }
+    v_summary
+  }
+  # get length and output names, calculated on the first variable
+  out1 <- create_summary_list(x, variables[1])
+  the_names <- vector(mode = "list", length = length(funs))
+  for (i in seq_along(out1)){
+    if (rlang::is_named(out1[[i]])) {
+      the_names[[i]] <- names(out1[[i]])
+    } else if (length(out1[[i]]) > 1) {
+      the_names[[i]] <- paste0(names(out1)[i], ".", c(1:length(out1[[i]])))
+    } else {
+      the_names[[i]] <- names(out1)[i]
+    }
+  }
+  the_names <- unlist(the_names)
+  # Check for naming issues prior do doing lengthy computation
+  if ("variable" %in% the_names) {
+    stop_no_call("Name 'variable' is reserved in 'summarise_draws'.")
+  }
+  # Pre-allocate matrix to store output
+  out <- matrix(NA, nrow = length(variables), ncol = length(the_names))
+  colnames(out) <- the_names
+  out[1, ] <- unlist(out1)
+  # Do the computation for all remaining variables
+  if (length(variables) > 1L) {
+    for (v_ind in 2:length(variables)) {
+      out_v <- create_summary_list(x, variables[v_ind])
+      out[v_ind, ] <- unlist(out_v)
+    }
+  }
+  out <- tibble::as_tibble(out)
+  out$variable <- variables
+  out <- move_to_start(out, "variable")
+  class(out) <- class_draws_summary()
+  out
 }
 
 #' @rdname draws_summary

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -151,10 +151,10 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   # Pre-allocate matrix to store output
   out <- matrix(NA, nrow = length(variables), ncol = length(unlist(out1)))
   colnames(out) <- the_names
-  out[1,] <- unlist(out1)
+  out[1, ] <- unlist(out1)
   
   # Do the computation for all remaining variables
-  if(length(variables) > 1L){
+  if (length(variables) > 1L) {
     for (v_ind in 2:length(variables)) {
       v <- variables[v_ind]
       draws <- drop_dims(x[, , v], dims = 3)

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -158,7 +158,7 @@ summarise_draws.draws <- function(x, ..., .args = list()) {
   if (length(variables) > 1L) {
     for (v_ind in 2:length(variables)) {
       v <- variables[v_ind]
-      draws <- drop_dims_or_classes(x[, , v], dims = 3)
+      draws <- drop_dims_or_classes(x[, , v], dims = 3, reset_class = FALSE)
       args <- c(list(draws), .args)
       out_v <- vector(mode = "list", length = length(funs))
       for (m in names(funs)) {

--- a/tests/testthat/test-summarise_draws.R
+++ b/tests/testthat/test-summarise_draws.R
@@ -62,3 +62,9 @@ test_that("summarise_draws and summary work for rvars", {
   expect_identical(summarise_draws(d$theta), ref)
   expect_identical(summary(d$theta), ref)
 })
+
+test_that("summarise_draws warns if all variable names are reserved", {
+  x <- subset_draws(as_draws_df(example_draws()), variable = "mu")
+  variables(x) <- ".log_weight"
+  expect_warning(summarize_draws(x), "no variables with unreserved names")
+})


### PR DESCRIPTION
This can close https://github.com/stan-dev/posterior/issues/98.

`summarise_draws` now internally writes output to a preallocated matrix, which makes the "chunking" option unnecessary except for parallelization, which will be dealt with separately.  

Additionally, we now check whether
```
  if ("variable" %in% the_names) {
    stop2("Name 'variable' is reserved in 'summarise_draws'.")
  }
```
prior to the potentially lengthy computation.

Benchmarks are:

```
remotes::install_github("jsocolar/posterior")
library(posterior)
library(microbenchmark)

set.seed(1)
nc <- 4

n <- 100
test_array <- array(data = rnorm(1000*nc*n), dim = c(1000,nc,n))
y <- posterior::as_draws_array(test_array)

b100 <- microbenchmark(m_s <- posterior::summarise_draws(y), times = 10)
# .786 sec under current posterior
# .79 sec under new version

n <- 1000
test_array <- array(data = rnorm(1000*nc*n), dim = c(1000,nc,n))
y <- posterior::as_draws_array(test_array)

b1000 <- microbenchmark(m_s <- posterior::summarise_draws(y), times = 2)
# 7.5 sec under current posterior
# 7.5 sec under new version

n <- 10000
test_array <- array(data = rnorm(1000*nc*n), dim = c(1000,nc,n))
y <- posterior::as_draws_array(test_array)

b10000 <- microbenchmark(m_s <- posterior::summarise_draws(y), times = 1)
# 84 under current posterior
# 73.5 sec under new version

n <- 50000
test_array <- array(data = rnorm(1000*nc*n), dim = c(1000,nc,n))
y <- posterior::as_draws_array(test_array)

b50000 <- microbenchmark(m_s <- posterior::summarise_draws(y), times = 1)
# 701 sec under current posterior
# 385 sec under new version
```