### PR TITLE
Updated as_draws_df()

### DIFF
--- a/R/as_draws_df.R
+++ b/R/as_draws_df.R
@@ -61,13 +61,12 @@ as_draws_df.draws_df <- function(x, ...) {
 #' @rdname draws_df
 #' @export
 as_draws_df.draws_matrix <- function(x, ...) {
-  class(x) <- "matrix"
-  draws <- as.integer(rownames(x))
-  rownames(x) <- NULL
+  if (ndraws(x) == 0L) {
+    return(empty_draws_df(variables(x)))
+  }
   x <- tibble::as_tibble(x)
-  x$.chain <- rep(1L, nrow(x))
-  x$.iteration <- draws
-  x$.draw <- draws
+  x[".chain"] <- 1L
+  x[c(".iteration", ".draw")] <- 1L:nrow(x)
   class(x) <- class_draws_df()
   x
 }
@@ -75,44 +74,37 @@ as_draws_df.draws_matrix <- function(x, ...) {
 #' @rdname draws_df
 #' @export
 as_draws_df.draws_array <- function(x, ...) {
-  if (ndraws(x) == 0) {
+  if (ndraws(x) == 0L) {
     return(empty_draws_df(variables(x)))
   }
   iteration_ids <- iteration_ids(x)
   chain_ids <- chain_ids(x)
-  rownames(x) <- NULL
-  out <- named_list(chain_ids)
-  for (i in seq_along(out)) {
-    out[[i]] <- drop_dims_or_classes(x[, i, ], dims = 2, reset_class = TRUE)
-    class(out[[i]]) <- "matrix"
-    out[[i]] <- tibble::as_tibble(out[[i]])
-    out[[i]]$.chain <- chain_ids[i]
-    out[[i]]$.iteration <- iteration_ids
-    out[[i]]$.draw <- compute_draw_ids(chain_ids[i], iteration_ids)
-  }
-  out <- do.call(rbind, out)
-  class(out) <- class_draws_df()
-  out
+  x <- apply(x, 3L, c)
+  x <- tibble::as_tibble(x)
+  x[".chain"] <- rep(chain_ids, each = max(iteration_ids))
+  x[".iteration"] <- rep(iteration_ids, max(chain_ids))
+  x[".draw"] <- 1L:nrow(x)
+  class(x) <- class_draws_df()
+  x
 }
 
 #' @rdname draws_df
 #' @export
 as_draws_df.draws_list <- function(x, ...) {
-  if (ndraws(x) == 0) {
+  if (ndraws(x) == 0L) {
     return(empty_draws_df(variables(x)))
   }
   iteration_ids <- iteration_ids(x)
   chain_ids <- chain_ids(x)
-  out <- named_list(chain_ids)
-  for (i in seq_along(out)) {
-    out[[i]] <- tibble::as_tibble(x[[i]])
-    out[[i]]$.chain <- chain_ids[i]
-    out[[i]]$.iteration <- iteration_ids
-    out[[i]]$.draw <- compute_draw_ids(chain_ids[i], iteration_ids)
-  }
-  out <- do.call(rbind, out)
-  class(out) <- class_draws_df()
-  out
+  vars <- names(x[[1L]])
+  x <- do.call(rbind.data.frame, x)
+  colnames(x) <- vars
+  x <- tibble::as_tibble(x)
+  x[".chain"] <- rep(chain_ids, each = max(iteration_ids))
+  x[".iteration"] <- rep(iteration_ids, max(chain_ids))
+  x[".draw"] <- 1L:nrow(x)
+  class(x) <- class_draws_df()
+  x
 }
 
 #' @rdname draws_df
@@ -154,9 +146,9 @@ as_draws_df.mcmc.list <- function(x, ...) {
   }
   if (has_iteration_column) {
     iteration_ids <- x[[.iteration]]
-    x[[.iteration]] <- NULL
+    x[.iteration] <- NULL
   } else {
-    iteration_ids <- seq_len(NROW(x))
+    iteration_ids <- 1L:nrow(x)
   }
   # prepare chain indices
   if (!is.null(.chain)) {
@@ -171,22 +163,22 @@ as_draws_df.mcmc.list <- function(x, ...) {
   }
   if (has_chain_column) {
     chain_ids <- x[[.chain]]
-    x[[.chain]] <- NULL
+    x[.chain] <- NULL
   } else {
-    chain_ids <- rep(1L, NROW(x))
+    chain_ids <- rep(1L, nrow(x))
   }
   # prepare draw indices --- i.e. drop them, since they are regenerated below
-  x[[".draw"]] <- NULL
+  x[".draw"] <- NULL
 
   # add reserved variables to the data
   check_new_variables(names(x))
-  x$.chain <- chain_ids
-  x$.iteration <- iteration_ids
+  x[".chain"] <- chain_ids
+  x[".iteration"] <- iteration_ids
   if (has_iteration_column || has_chain_column) {
-    x$.chain <- repair_chain_ids(x$.chain)
-    x$.iteration <- repair_iteration_ids(x$.iteration, x$.chain)
+    x[".chain"] <- repair_chain_ids(x[[".chain"]])
+    x[".iteration"] <- repair_iteration_ids(x[[".iteration"]], x[[".chain"]])
   }
-  x$.draw <- compute_draw_ids(x$.chain, x$.iteration)
+  x[".draw"] <- compute_draw_ids(x[[".chain"]], x[[".iteration"]])
   class(x) <- class_draws_df()
   x
 }
@@ -205,8 +197,8 @@ draws_df <- function(..., .nchains = 1) {
   }
   niterations <- ndraws %/% .nchains
   out <- as.data.frame(out, optional = TRUE)
-  out$.iteration <- rep(1L:niterations, .nchains)
-  out$.chain <- rep(1L:.nchains, each = niterations)
+  out[".iteration"] <- rep(1L:niterations, .nchains)
+  out[".chain"] <- rep(1L:.nchains, each = niterations)
   as_draws_df(out)
 }
 
@@ -245,13 +237,9 @@ is_draws_df_like <- function(x) {
 # create an empty draws_df object
 empty_draws_df <- function(variables = character(0)) {
   assert_character(variables, null.ok = TRUE)
-  out <- tibble::tibble()
-  for (v in variables) {
-    out[[v]] <- numeric(0)
-  }
-  out$.chain <- integer(0)
-  out$.iteration <- integer(0)
-  out$.draw <- integer(0)
-  class(out) <- class_draws_df()
-  out
+  x <- tibble::tibble()
+  x[variables] <- numeric(0)
+  x[c(".chain", ".iteration", ".draw")] <- integer(0)
+  class(x) <- class_draws_df()
+  x
 }

--- a/R/as_draws_df.R
+++ b/R/as_draws_df.R
@@ -66,7 +66,7 @@ as_draws_df.draws_matrix <- function(x, ...) {
   }
   x <- tibble::as_tibble(x)
   x[".chain"] <- 1L
-  x[c(".iteration", ".draw")] <- 1L:nrow(x)
+  x[c(".iteration", ".draw")] <- seq_len(nrow(x))
   class(x) <- class_draws_df()
   x
 }
@@ -83,7 +83,7 @@ as_draws_df.draws_array <- function(x, ...) {
   x <- tibble::as_tibble(x)
   x[".chain"] <- rep(chain_ids, each = max(iteration_ids))
   x[".iteration"] <- rep(iteration_ids, max(chain_ids))
-  x[".draw"] <- 1L:nrow(x)
+  x[".draw"] <- seq_len(nrow(x))
   class(x) <- class_draws_df()
   x
 }
@@ -102,7 +102,7 @@ as_draws_df.draws_list <- function(x, ...) {
   x <- tibble::as_tibble(x)
   x[".chain"] <- rep(chain_ids, each = max(iteration_ids))
   x[".iteration"] <- rep(iteration_ids, max(chain_ids))
-  x[".draw"] <- 1L:nrow(x)
+  x[".draw"] <- seq_len(nrow(x))
   class(x) <- class_draws_df()
   x
 }
@@ -148,7 +148,7 @@ as_draws_df.mcmc.list <- function(x, ...) {
     iteration_ids <- x[[.iteration]]
     x[.iteration] <- NULL
   } else {
-    iteration_ids <- 1L:nrow(x)
+    iteration_ids <- seq_len(nrow(x))
   }
   # prepare chain indices
   if (!is.null(.chain)) {
@@ -197,8 +197,8 @@ draws_df <- function(..., .nchains = 1) {
   }
   niterations <- ndraws %/% .nchains
   out <- as.data.frame(out, optional = TRUE)
-  out[".iteration"] <- rep(1L:niterations, .nchains)
-  out[".chain"] <- rep(1L:.nchains, each = niterations)
+  out[".iteration"] <- rep(seq_len(niterations), .nchains)
+  out[".chain"] <- rep(seq_len(.nchains), each = niterations)
   as_draws_df(out)
 }
 

--- a/R/draws-index.R
+++ b/R/draws-index.R
@@ -452,7 +452,7 @@ check_existing_variables <- function(variables, x, regex = FALSE,
     stop_no_call("The following variables are missing in the draws object: ",
           comma(missing_variables))
   }
-  variables
+  invisible(variables)
 }
 
 # check validity of new variables: e.g., that there are
@@ -482,7 +482,7 @@ check_reserved_variables <- function(variables) {
   if (length(used_reserved_variables)) {
     stop_no_call("Variable names ", comma(used_reserved_variables), " are reserved.")
   }
-  variables
+  invisible(variables)
 }
 
 # check validity of iteration indices
@@ -507,7 +507,7 @@ check_iteration_ids <- function(iteration_ids, x, unique = TRUE) {
     stop_no_call("Tried to subset iterations up to '", max_iteration, "' ",
           "but the object only has '", niterations, "' iterations.")
   }
-  iteration_ids
+  invisible(iteration_ids)
 }
 
 # check validity of chain indices
@@ -532,7 +532,7 @@ check_chain_ids <- function(chain_ids, x, unique = TRUE) {
     stop_no_call("Tried to subset chains up to '", max_chain, "' ",
           "but the object only has '", nchains, "' chains.")
   }
-  chain_ids
+  invisible(chain_ids)
 }
 
 # check validity of draw indices
@@ -557,5 +557,5 @@ check_draw_ids <- function(draw_ids, x, unique = TRUE) {
     stop_no_call("Tried to subset draws up to '", max_draw, "' ",
           "but the object only has '", ndraws, "' draws.")
   }
-  draw_ids
+  invisible(draw_ids)
 }

--- a/R/repair_draws.R
+++ b/R/repair_draws.R
@@ -140,6 +140,7 @@ repair_chain_ids <- function(chain_ids) {
 #' @param iteration_ids A vector of iteration indices
 #' @noRd
 compute_draw_ids <- function(chain_ids, iteration_ids) {
+  assert_true(length(chain_ids) == length(iteration_ids))
   niterations <- SW(max(iteration_ids))
   out <- (chain_ids - 1L) * niterations + iteration_ids
   as.integer(out)

--- a/tests/testthat/test-as_draws.R
+++ b/tests/testthat/test-as_draws.R
@@ -189,7 +189,7 @@ test_that("numeric vectors can be transformed to draws_array objects", {
   draws_array2 <- array(c(1:10, 11:20, rep(1, 10)), c(5, 2, 3))
   dimnames(draws_array2)[[3]] <- c("a", "b", "c")
   draws_array2 <- as_draws_array(draws_array2)
-  expect_equivalent(draws_array, draws_array2)
+  expect_equal(draws_array, draws_array2)
 })
 
 test_that("numeric vectors can be transformed to draws_df objects", {
@@ -197,7 +197,7 @@ test_that("numeric vectors can be transformed to draws_df objects", {
   draws_array <- array(c(1:10, 11:20, rep(1, 10)), c(5, 2, 3))
   dimnames(draws_array)[[3]] <- c("a", "b", "c")
   draws_df2 <- as_draws_df(draws_array)
-  expect_equivalent(draws_df, draws_df2)
+  expect_equal(draws_df, draws_df2)
 })
 
 test_that("numeric vectors can be transformed to draws_list objects", {
@@ -205,7 +205,7 @@ test_that("numeric vectors can be transformed to draws_list objects", {
   draws_array <- array(c(1:10, 11:20, rep(1, 10)), c(5, 2, 3))
   dimnames(draws_array)[[3]] <- c("a", "b", "c")
   draws_list2 <- as_draws_list(draws_array)
-  expect_equivalent(draws_list, draws_list2)
+  expect_equal(draws_list, draws_list2)
 })
 
 test_that("numeric vectors can be transformed to draws_rvars objects", {
@@ -213,7 +213,7 @@ test_that("numeric vectors can be transformed to draws_rvars objects", {
   draws_array <- array(c(1:10, 11:20, rep(1, 10)), c(5, 2, 3))
   dimnames(draws_array)[[3]] <- c("a", "b", "c")
   draws_rvars2 <- as_draws_rvars(draws_array)
-  expect_equivalent(draws_rvars, draws_rvars2)
+  expect_equal(draws_rvars, draws_rvars2)
 })
 
 test_that("mcmc and mcmc.list objects can be transformed to draws objects", {

--- a/tests/testthat/test-subset_draws.R
+++ b/tests/testthat/test-subset_draws.R
@@ -142,6 +142,5 @@ test_that("non-unique subsetting for draws_df same as doing it with draws_list",
                            unique = FALSE)
   x_list_sub <- subset_draws(x_list, chain = c(1,1,2), iteration = c(1:2, 1:50),
                              unique = FALSE)
-  expect_equivalent(x_df_sub, as_draws_df(x_list_sub))
+  expect_equal(x_df_sub, as_draws_df(x_list_sub))
 })
-


### PR DESCRIPTION
Fixes #134 and and speeds up `as_draws_df()`:
- makes the `as_draws_df` methods vectorized, faster and more concise
- resolves row name inconsistencies that occur after transformations from various classes to `draws_df`
- switches to invisible returns for `check_*_*()` functions to prevent their output from getting printed
- enforces equal input lengths in `compute_draw_ids()` to avoid incorrect outputs due to recycling of vector elements
- applies more strict tests in relevant parts