### PR TITLE
Continuous benchmarking

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^bench$

--- a/.github/workflows/continuous-benchmarks.yaml
+++ b/.github/workflows/continuous-benchmarks.yaml
@@ -1,0 +1,31 @@
+on: push
+
+name: Continuous Benchmarks
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@master
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@master
+
+      - name: Install dependencies
+        run: |
+          Rscript -e "install.packages(c('remotes'))" -e "remotes::install_deps(dependencies = TRUE)"
+          Rscript -e "remotes::install_github("r-lib/bench")"
+          R CMD INSTALL .
+
+      - name: Fetch existing benchmarks
+        run: Rscript -e 'bench::cb_fetch()'
+
+      - name: Run benchmarks
+        run: Rscript -e 'bench::cb_run()'
+
+      - name: Show benchmarks
+        run: git notes --ref benchmarks show
+
+      - name: Push benchmarks
+        run: Rscript -e "bench::cb_push()"

--- a/.github/workflows/continuous-benchmarks.yaml
+++ b/.github/workflows/continuous-benchmarks.yaml
@@ -5,18 +5,40 @@ name: Continuous Benchmarks
 jobs:
   build:
     runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
+      - uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
 
-      - name: Setup R
-        uses: r-lib/actions/setup-r@master
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install dependencies
         run: |
-          Rscript -e "install.packages(c('remotes'))" -e "remotes::install_deps(dependencies = TRUE)"
-          Rscript -e "remotes::install_github("r-lib/bench")"
-          R CMD INSTALL .
+          install.packages(c("remotes"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_github("r-lib/bench")
+        shell: Rscript {0}
 
       - name: Fetch existing benchmarks
         run: Rscript -e 'bench::cb_fetch()'

--- a/.github/workflows/continuous-benchmarks.yaml
+++ b/.github/workflows/continuous-benchmarks.yaml
@@ -1,4 +1,12 @@
-on: push
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
 
 name: Continuous Benchmarks
 

--- a/.github/workflows/continuous-benchmarks.yaml
+++ b/.github/workflows/continuous-benchmarks.yaml
@@ -35,9 +35,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("remotes"))
+          install.packages(c("remotes","devtools"))
           remotes::install_deps(dependencies = TRUE)
           remotes::install_github("r-lib/bench")
+        shell: Rscript {0}
+
+      - name: Install package
+        run: |
+          devtools::install()
         shell: Rscript {0}
 
       - name: Fetch existing benchmarks

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Suggests:
   dplyr,
   tidyr,
   knitr,
+  bench,
   rmarkdown
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8

--- a/bench/README.Rmd
+++ b/bench/README.Rmd
@@ -1,0 +1,77 @@
+---
+title: "Benchmarks for posterior"
+output: github_document
+---
+
+```{r setup, message = FALSE}
+library(bench)
+library(ggplot2)
+library(dplyr)
+library(tidyr)
+library(here)
+
+theme_set(
+  theme_light() +
+  theme(
+    axis.line.x = element_line(color = "gray70", size = rel(0.5)),
+    axis.line.y = element_line(color = "gray70", size = rel(0.5)),
+    axis.title.x = element_text(margin = margin(t = 7)), 
+    axis.title.y = element_text(margin = margin(r = 7)), 
+    panel.border = element_rect(fill = NA, colour = "grey87", size = rel(0.5)),
+    strip.text = element_text(color = "black", margin = margin(6, 6, 6, 6)),
+    strip.background = element_rect(fill = "gray90")
+  )  
+)
+```
+
+## Running benchmarks
+
+The continuous benchmarks in posterior use the Github version of [bench](https://github.com/r-lib/bench)
+(the CRAN version does not support continuous benchmarks yet). Thus you must
+install the version of bench from Github.
+
+Benchmarks are stored in `bench/` and you can run them locally via `bench::cb_run()`.
+**However,** pushing local runs of the benchmarks to the server may not be advisable
+as they may not be comparable to the remote machine benchmarks.
+Remote benchmarks are run using continuous integration on Github and stored as
+git notes. You can fetch these benchmarks via:
+
+```{r}
+# bench::cb_ functions require that we are in the project root directory
+setwd(here::here())
+
+bench::cb_fetch()
+cb <- bench::cb_read()
+```
+
+The `cb` object stores benchmarks as nested tibbles:
+
+```{r}
+cb %>%
+  filter(lengths(benchmarks) > 0) %>%
+  select(-commit_hash)
+```
+
+I find the default plot for continuous benchmarks in `bench` (in `bench::plot_time()`)
+a bit hard to read; the following code is a modified version of it that shows benchmarks
+from the `bench/as_draws.R` file:
+
+```{r, fig.height = 8, fig.width = 8}
+cb %>%
+  filter(lengths(benchmarks) > 0) %>%
+  head(5) %>%
+  unnest(benchmarks) %>%
+  mutate(pretty_name = bench:::get_pretty_names(cur_data_all())) %>%
+  filter(file == "as_draws.R") %>%
+  ggplot(aes(y = pretty_name, x = p50, xmin = p25, xmax = p75, color = os)) +
+  geom_line(aes(group = NA), color = "gray50") +
+  geom_pointrange() +
+  scale_x_bench_time() +
+  facet_wrap(vars(name), ncol = 4) +
+  theme(legend.position = "bottom") +
+  labs(
+    y = NULL,
+    x = "Benchmark time",
+    color = NULL
+  )
+```

--- a/bench/as_draws.R
+++ b/bench/as_draws.R
@@ -1,4 +1,5 @@
 # Benchmarks for conversion between draws formats
+library(posterior)
 
 iterations <- 500
 chains <- 4

--- a/bench/as_draws.R
+++ b/bench/as_draws.R
@@ -1,0 +1,53 @@
+# Benchmarks for conversion between draws formats
+
+iterations <- 500
+chains <- 4
+I <- 30
+J <- 30
+x_array <- as_draws_array(array(1:(iterations*chains*I*J), dim = c(iterations, chains, I*J), dimnames = list(
+  NULL, NULL, paste0("x[", rep(as.roman(1:I), each = J), ",", rep(as.roman(1:J), I), "]")
+)))
+
+# conversion from draws_array
+bench::mark(check = FALSE, min_iterations = 20, filter_gc = FALSE,
+  as_draws_matrix(x_array),
+  as_draws_list(x_array),
+  as_draws_df(x_array),
+  as_draws_rvars(x_array)
+)
+
+# conversion from draws_matrix
+x_matrix <- as_draws_matrix(x_array)
+bench::mark(check = FALSE, min_iterations = 20, filter_gc = FALSE,
+  as_draws_array(x_matrix),
+  as_draws_list(x_matrix),
+  as_draws_df(x_matrix),
+  as_draws_rvars(x_matrix)
+)
+
+# conversion from draws_list
+x_list <- as_draws_list(x_array)
+bench::mark(check = FALSE, min_iterations = 20, filter_gc = FALSE,
+  as_draws_array(x_list),
+  as_draws_matrix(x_list),
+  as_draws_df(x_list),
+  as_draws_rvars(x_list)
+)
+
+# conversion from draws_df
+x_df <- as_draws_df(x_array)
+bench::mark(check = FALSE, min_iterations = 20, filter_gc = FALSE,
+  as_draws_array(x_df),
+  as_draws_matrix(x_df),
+  as_draws_list(x_df),
+  as_draws_rvars(x_df)
+)
+
+# conversion from draws_rvars
+x_rvars <- as_draws_rvars(x_array)
+bench::mark(check = FALSE, min_iterations = 20, filter_gc = FALSE,
+  as_draws_array(x_rvars),
+  as_draws_matrix(x_rvars),
+  as_draws_list(x_rvars),
+  as_draws_df(x_rvars)
+)


### PR DESCRIPTION
This is an attempt at using the development version of bench to do continuous benchmarking. I have no idea if we want to merge something like this in at this time, but it seems to more-or-less work so I thought I'd see what folks think. I'm very open to suggestions on how to make this process work better.

I added a README about in `bench/README.Rmd`. Basic idea is that a Github action will run benchmarks and store them in the [git notes](https://git-scm.com/docs/git-notes) attached to the commit. You can then use `bench::cb_fetch()` to grab benchmarks and plot them. You can also run them yourself with `bench::cb_run()` locally. 

Benchmarks are stored in the `bench/` folder. I added one example benchmarking the performance of converting draws objects between the various formats (this benchmark can probably be improved). 

There isn't any automated reporting at the moment, but I figured that for now folks can just add relevant plots to the README and run it manually when doing benchmarking-related work. Currently it just outputs this one plot:

![image](https://user-images.githubusercontent.com/6345019/119300961-460dfb80-bc27-11eb-8633-a9c5464be51a.png)

which doesn't show anything meaningful at the moment since those two benchmarks were run on different machines.

You do have to install the github version of bench to run the `cb_XXX()` functions. I did not make this a requirement on the package via `Remotes:`, because CRAN does not allow that field; instead the github action manually grabs the github version of bench.