### PR TITLE
Licenses 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+#### Summary
+
+Please describe the purpose of the pull request. 
+
+#### Copyright and Licensing
+
+By submitting this pull request, the copyright holder is agreeing to 
+license the submitted work under the following licenses:
+
+- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
+- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,2 @@
-Copyright (c) 2019 Stan Developers and their Assignees; Trustees of Columbia University; Paul Bürkner; Jonah Gabry; Matthew Kay; Aki Vehtari; 
+YEAR: 2021
+COPYRIGHT HOLDER: posterior package authors; Stan Developers and their Assignees; and Trustees of Columbia University

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019 Stan Developers and their Assignees; Trustees of Columbia University; Paul Bürkner; Jonah Gabry; Matthew Kay; Aki Vehtari;
+Copyright (c) 2021 posterior package authors; Stan Developers and their Assignees; Trustees of Columbia University
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -405,3 +405,10 @@ Chapman and Hall/CRC.
 Vehtari A., Gelman A., Simpson D., Carpenter B., & Bürkner P. C. (2020).
 Rank-normalization, folding, and localization: An improved Rhat for
 assessing convergence of MCMC. *Bayesian Analysis*.
+
+### Licensing
+
+The **posterior** package is licensed under the following licenses:
+
+- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
+- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
Addresses the suggestions from @rok-cesnovar in https://github.com/stan-dev/posterior/issues/126#issuecomment-846602142. 

* Adds note to README about licenses for code and doc
* Adds PR template with note about agreeing to licenses 
* Updates LICENSE file to be CRAN compliant (LICENSE.md has the full license) 
