### PR TITLE
ensure base vectors are promoted to row/col vectors in rvar matrix mult

### DIFF
--- a/R/rvar-math.R
+++ b/R/rvar-math.R
@@ -96,6 +96,11 @@ Math.rvar <- function(x, ...) {
 `%**%` <- function(x, y) {
   # Fast version of rdo(x %*% y)
 
+  # convert both objects into rvars if they aren't already (this will ensure
+  # we have a 3d draws array for each variable)
+  x <- as_rvar(x)
+  y <- as_rvar(y)
+
   # ensure everything is a matrix by adding dimensions as necessary to make `x`
   # a row vector and `y` a column vector
   ndim_x <- length(dim(x))
@@ -111,11 +116,6 @@ Math.rvar <- function(x, ...) {
   } else if (ndim_y != 2) {
     stop_no_call("Second argument (`y`) is not a vector or matrix, cannot matrix-multiply")
   }
-
-  # convert both objects into rvars if they aren't already (this will give us
-  # a 3d draws array for each variable)
-  x <- as_rvar(x)
-  y <- as_rvar(y)
 
   # conform the draws dimension in both variables
   c(x, y) %<-% conform_rvar_ndraws_nchains(list(x, y))

--- a/tests/testthat/test-rvar-math.R
+++ b/tests/testthat/test-rvar-math.R
@@ -145,6 +145,18 @@ test_that("matrix multiplication works", {
   ))
   expect_identical(x %**% y, xy_ref)
 
+  # automatic promotion to row/col vector of numeric vectors
+  x_meany_ref = new_rvar(abind::abind(along = 0,
+    x_array[1,] %*% colMeans(y_array),
+    x_array[2,] %*% colMeans(y_array)
+  ))
+  expect_identical(x %**% colMeans(y_array), x_meany_ref)
+
+  meanx_y_ref = new_rvar(abind::abind(along = 0,
+    colMeans(x_array) %*% y_array[1,],
+    colMeans(x_array) %*% y_array[2,]
+  ))
+  expect_identical(colMeans(x_array) %**% y, meanx_y_ref)
 
   # dimension name preservation
   m1 <- as_rvar(diag(1:3))


### PR DESCRIPTION
In base R bare vectors (without dims) are promoted to row/col vectors depending on if they are on the left or right side of `%*%`. e.g. this works:

```r
c(1.5, 3.5, 5.5) %*% c(7.5,  9.5, 11.5)
```
```
       [,1]
[1,] 107.75
```

Currently this promotion works with rvars so long as both sides are rvars:

```r
x_array = array(1:6, dim = c(2,3))
x = new_rvar(x_array)
y_array = array(7:12, dim = c(2,3))
y = new_rvar(y_array)
x
```
```
rvar<2>[3] mean ± sd:
[1] 1.5 ± 0.71  3.5 ± 0.71  5.5 ± 0.71 
```
```r
y
```
```
rvar<2>[3] mean ± sd:
[1]  7.5 ± 0.71   9.5 ± 0.71  11.5 ± 0.71 
```
```r
x %**% y
```
```
rvar<2>[1,1] mean ± sd:
     [,1]     
[1,] 108 ± 28 
```

But fails if one side is not an rvar:

```r
x %**% c(7.5,  9.5, 11.5)
```
```
Error: Second argument (`y`) is not a vector or matrix, cannot matrix-multiply
```

It is easy enough to work around (by either promoting the vector or converting it to a constant rvar), but doing so is still a bit cumbersome.

This PR adds a fix and a test so that base vectors on the left/right are promoted appropriately:

```r
x %**% c(7.5,  9.5, 11.5)
```
```
rvar<2>[1,1] mean ± sd:
     [,1]     
[1,] 108 ± 20 
```
