### PR TITLE
add @return for remaining doc pages except reserved-variables

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -25,6 +25,9 @@
 #' | [rhat()] | Improved, rank-based version of Rhat |
 #' | [rstar()] | R* diagnostic |
 #'
+#' @return
+#' See individual functions for a description of return types.
+#'
 NULL
 
 #' Basic version of the Rhat convergence diagnostic
@@ -487,6 +490,11 @@ mcse_sd.rvar <- function(x, ...) {
 #'   to computing quantiles? The default is `FALSE`.
 #' @param ... Arguments passed to individual methods (if applicable) and then
 #'   on to [stats::quantile()].
+#'
+#' @return
+#' A numeric vector of length `length(probs)`. If `names = TRUE`, it has a
+#' [names] attribute with names like `"q5"`, `"q95"`, etc, based on the values
+#' of `probs`.
 #'
 #' @examples
 #' mu <- extract_variable_matrix(example_draws(), "mu")

--- a/R/draws-index.R
+++ b/R/draws-index.R
@@ -19,6 +19,14 @@
 #' similar to how `names(x) <- value` works for vectors and lists. For renaming
 #' specific variables, [rename_variables()] may offer a more convenient approach.
 #'
+#' @return
+#'
+#' For `variables()`, a character vector.
+#'
+#' For `iteration_ids()`, `chain_ids()`, and `draw_ids()`, an integer vector.
+#'
+#' For `niterations()`, `nchains()`, and `ndraws()`, a scalar integer.
+#'
 #' @examples
 #' x <- example_draws()
 #'

--- a/R/rvar-.R
+++ b/R/rvar-.R
@@ -154,6 +154,14 @@ new_rvar <- function(x = double(), .nchains = 1L) {
 #' so that the first dimension is the index of the iterations and the second
 #' dimension is the index of the chains.
 #'
+#' @return
+#'
+#' If `with_chains = FALSE`, an array with dimensions `c(ndraws(x), dim(x))`.
+#'
+#' If `with_chains = TRUE`, an array with dimensions
+#' `c(niterations(x), nchains(x), dim(x))`.
+#'
+#'
 #' @examples
 #'
 #' x <- rvar(1:10, nchains = 2)

--- a/R/rvar-cast.R
+++ b/R/rvar-cast.R
@@ -192,12 +192,12 @@ vec_restore.rvar <- function(x, ...) {
 #' @param ... Further arguments passed to other functions.
 #' @param x_arg,y_arg Argument names for `x` and `y`.
 #'
-#' @details
+#' @return
 #'
-#' See the corresponding functions in [vctrs-package] for more information.
+#' See the corresponding functions in [vctrs-package] for more information,
+#' or `vignette("s3-vector", package = "vctrs")` for examples.
 #'
-#' @seealso [vctrs::vec_cast()],[vctrs::vec_ptype2()],[vctrs::vec_arith()],
-#' [vctrs::vec_math()]
+#' @seealso [vctrs::vec_cast()], [vctrs::vec_ptype2()]
 #'
 #' @importFrom vctrs vec_ptype vec_ptype2 vec_default_ptype2
 #' @method vec_ptype2 rvar

--- a/man/diagnostics.Rd
+++ b/man/diagnostics.Rd
@@ -4,6 +4,9 @@
 \alias{diagnostics}
 \alias{convergence}
 \title{List of available convergence diagnostics}
+\value{
+See individual functions for a description of return types.
+}
 \description{
 A list of available diagnostics and links to their individual help pages.
 }

--- a/man/draws-index.Rd
+++ b/man/draws-index.Rd
@@ -40,6 +40,13 @@ is defined.}
 \item{value}{(character vector) For \code{variables(x) <- value}, the new variable
 names to use.}
 }
+\value{
+For \code{variables()}, a character vector.
+
+For \code{iteration_ids()}, \code{chain_ids()}, and \code{draw_ids()}, an integer vector.
+
+For \code{niterations()}, \code{nchains()}, and \code{ndraws()}, a scalar integer.
+}
 \description{
 Index variables, iterations, chains, and draws.
 }

--- a/man/draws_of.Rd
+++ b/man/draws_of.Rd
@@ -19,6 +19,12 @@ dimension \code{c(niterations(x), nchains(x), dim(x))}.}
 
 \item{value}{(array) An array of values to use as the backing array of \code{x}.}
 }
+\value{
+If \code{with_chains = FALSE}, an array with dimensions \code{c(ndraws(x), dim(x))}.
+
+If \code{with_chains = TRUE}, an array with dimensions
+\code{c(niterations(x), nchains(x), dim(x))}.
+}
 \description{
 Gets/sets the array-representation that backs an \code{\link{rvar}}. Should be used rarely.
 }

--- a/man/quantile2.Rd
+++ b/man/quantile2.Rd
@@ -32,6 +32,11 @@ on to \code{\link[stats:quantile]{stats::quantile()}}.}
 default is \code{TRUE}, but use \code{FALSE} for improved speed if there are many
 values in \code{probs}.}
 }
+\value{
+A numeric vector of length \code{length(probs)}. If \code{names = TRUE}, it has a
+\link{names} attribute with names like \code{"q5"}, \code{"q95"}, etc, based on the values
+of \code{probs}.
+}
 \description{
 Compute quantiles of a sample and return them in a format consistent
 with other summary functions in the \pkg{posterior} package.

--- a/man/vctrs-compat.Rd
+++ b/man/vctrs-compat.Rd
@@ -58,13 +58,13 @@
 
 \item{to}{Type to cast to.}
 }
+\value{
+See the corresponding functions in \link{vctrs-package} for more information,
+or \code{vignette("s3-vector", package = "vctrs")} for examples.
+}
 \description{
 These functions implement compatibility with \link{vctrs-package} for \code{\link{rvar}}s.
 }
-\details{
-See the corresponding functions in \link{vctrs-package} for more information.
-}
 \seealso{
-\code{\link[vctrs:vec_cast]{vctrs::vec_cast()}},\code{\link[vctrs:vec_ptype2]{vctrs::vec_ptype2()}},\code{\link[vctrs:vec_arith]{vctrs::vec_arith()}},
-\code{\link[vctrs:vec_math]{vctrs::vec_math()}}
+\code{\link[vctrs:vec_cast]{vctrs::vec_cast()}}, \code{\link[vctrs:vec_ptype2]{vctrs::vec_ptype2()}}
 }


### PR DESCRIPTION
This PR adds `@return`s for functions docs mentioned in #165, with the exception of `reserved-variables`.