### PR TITLE
make rstar example "donttest" instead of "dontrun"

### DIFF
--- a/R/rstar.R
+++ b/R/rstar.R
@@ -69,23 +69,23 @@
 #'   *arXiv preprint* `arXiv:2003.07900`.
 #'
 #' @examples
-#' \dontrun{
-#' library(caret)
-#' x <- example_draws("eight_schools")
-#' rstar(x)
-#' rstar(x, split = FALSE)
-#' rstar(x, method = "gbm")
-#' # can pass additional arguments to methods
-#' rstar(x, method = "gbm", verbose = FALSE)
+#' \donttest{
+#' if (require("caret", quietly = TRUE)) {
+#'   x <- example_draws("eight_schools")
+#'   print(rstar(x))
+#'   print(rstar(x, split = FALSE))
+#'   print(rstar(x, method = "gbm"))
+#'   # can pass additional arguments to methods
+#'   print(rstar(x, method = "gbm", verbose = FALSE))
 #'
-#' # with uncertainty, returns a vector of R* values
-#' hist(rstar(x, uncertainty = TRUE))
-#' hist(rstar(x, uncertainty = TRUE, nsimulations = 100))
+#'   # with uncertainty, returns a vector of R* values
+#'   hist(rstar(x, uncertainty = TRUE))
+#'   hist(rstar(x, uncertainty = TRUE, nsimulations = 100))
 #'
-#' # can use other classification methods in caret library
-#' rstar(x, method = "knn")
+#'   # can use other classification methods in caret library
+#'   print(rstar(x, method = "knn"))
 #' }
-#'
+#' }
 #' @export
 rstar <- function(x, split = TRUE,
                   uncertainty = FALSE,

--- a/man/rstar.Rd
+++ b/man/rstar.Rd
@@ -82,23 +82,23 @@ For lower dimensional targets, gradient boosted models (called via
 MCMC sample, it is recommended to try both of these classifiers.
 }
 \examples{
-\dontrun{
-library(caret)
-x <- example_draws("eight_schools")
-rstar(x)
-rstar(x, split = FALSE)
-rstar(x, method = "gbm")
-# can pass additional arguments to methods
-rstar(x, method = "gbm", verbose = FALSE)
+\donttest{
+if (require("caret", quietly = TRUE)) {
+  x <- example_draws("eight_schools")
+  print(rstar(x))
+  print(rstar(x, split = FALSE))
+  print(rstar(x, method = "gbm"))
+  # can pass additional arguments to methods
+  print(rstar(x, method = "gbm", verbose = FALSE))
 
-# with uncertainty, returns a vector of R* values
-hist(rstar(x, uncertainty = TRUE))
-hist(rstar(x, uncertainty = TRUE, nsimulations = 100))
+  # with uncertainty, returns a vector of R* values
+  hist(rstar(x, uncertainty = TRUE))
+  hist(rstar(x, uncertainty = TRUE, nsimulations = 100))
 
-# can use other classification methods in caret library
-rstar(x, method = "knn")
+  # can use other classification methods in caret library
+  print(rstar(x, method = "knn"))
 }
-
+}
 }
 \references{
 Ben Lambert, Aki Vehtari (2020) R*: A robust MCMC convergence


### PR DESCRIPTION
This changes the `rstar()` example from "dontrun" to "donttest", and also wraps it conditionally to run only if {caret} is installed (as {caret} is only in "Suggests"). For #165.