### PR TITLE
cache vec_proxy results as stopgap for r-lib/vctrs#1411

### DIFF
--- a/R/as_draws_rvars.R
+++ b/R/as_draws_rvars.R
@@ -139,7 +139,7 @@ as_draws_rvars.draws_matrix <- function(x, ...) {
   out <- .as_draws_rvars(rvars_list, ...)
   .nchains <- nchains(x)
   for (i in seq_along(out)) {
-    attr(out[[i]], "nchains") <- .nchains
+    nchains_rvar(out[[i]]) <- .nchains
   }
   out
 }

--- a/R/draws-index.R
+++ b/R/draws-index.R
@@ -384,6 +384,14 @@ nchains.draws_rvars <- function(x) {
 nchains.rvar <- function(x) {
   attr(x, "nchains") %||% 1L
 }
+# for internal use only currently: if you are setting the nchains
+# attribute on an rvar, ALWAYS use this function so that the proxy
+# cache is invalidated
+`nchains_rvar<-` <- function(x, value) {
+  attr(x, "nchains") <- value
+  invalidate_rvar_cache(x)
+}
+
 
 #' @rdname draws-index
 #' @export

--- a/R/merge_chains.R
+++ b/R/merge_chains.R
@@ -62,7 +62,7 @@ merge_chains.draws_list <- function(x, ...) {
 #' @rdname merge_chains
 #' @export
 merge_chains.rvar <- function(x, ...) {
-  attr(x, "nchains") <- 1L
+  nchains_rvar(x) <- 1L
   x
 }
 

--- a/R/rvar-print.R
+++ b/R/rvar-print.R
@@ -131,7 +131,7 @@ str.rvar <- function(
       }
     }
     str_attr(attributes(draws_of(object)), "draws_of(*)", c("names", "dim", "dimnames", "class"))
-    str_attr(attributes(object), "*", c("draws", "names", "dim", "dimnames", "class", "nchains"))
+    str_attr(attributes(object), "*", c("draws", "names", "dim", "dimnames", "class", "nchains", "cache"))
   }
 
   invisible(NULL)

--- a/R/subset_draws.R
+++ b/R/subset_draws.R
@@ -336,7 +336,7 @@ subset_dims <- function(x, ...) {
     slice_index <- chain_ids %in% chain
     for (i in seq_along(x)) {
       draws_of(x[[i]]) <- vec_slice(draws_of(x[[i]]), slice_index)
-      attr(x[[i]], "nchains") <- nchains
+      nchains_rvar(x[[i]]) <- nchains
     }
   }
   if (!is.null(iteration)) {

--- a/tests/testthat/test-rvar-.R
+++ b/tests/testthat/test-rvar-.R
@@ -123,9 +123,9 @@ test_that("rvars work in tibbles", {
   x = rvar_from_array(x_array)
   df = tibble::tibble(x, y = x + 1)
 
-  expect_identical(df$x, x)
-  expect_identical(df$y, rvar_from_array(x_array + 1))
-  expect_identical(dplyr::mutate(df, z = x)$z, x)
+  expect_equal(df$x, x)
+  expect_equal(df$y, rvar_from_array(x_array + 1))
+  expect_equal(dplyr::mutate(df, z = x)$z, x)
 
   expect_equal(dplyr::mutate(df, z = x * 2)$z, rvar_from_array(x_array * 2))
   expect_equal(

--- a/tests/testthat/test-rvar-math.R
+++ b/tests/testthat/test-rvar-math.R
@@ -6,29 +6,29 @@ test_that("math operators works", {
   y_array = array(c(2:13,12:1), dim = c(4,2,3))
   y = new_rvar(y_array)
 
-  expect_identical(log(x), new_rvar(log(x_array)))
+  expect_equal(log(x), new_rvar(log(x_array)))
 
-  expect_identical(-x, new_rvar(-x_array))
+  expect_equal(-x, new_rvar(-x_array))
 
-  expect_identical(x + 2, new_rvar(x_array + 2))
-  expect_identical(2 + x, new_rvar(x_array + 2))
-  expect_identical(x + y, new_rvar(x_array + y_array))
+  expect_equal(x + 2, new_rvar(x_array + 2))
+  expect_equal(2 + x, new_rvar(x_array + 2))
+  expect_equal(x + y, new_rvar(x_array + y_array))
 
-  expect_identical(x - 2, new_rvar(x_array - 2))
-  expect_identical(2 - x, new_rvar(2 - x_array))
-  expect_identical(x - y, new_rvar(x_array - y_array))
+  expect_equal(x - 2, new_rvar(x_array - 2))
+  expect_equal(2 - x, new_rvar(2 - x_array))
+  expect_equal(x - y, new_rvar(x_array - y_array))
 
-  expect_identical(x * 2, new_rvar(x_array * 2))
-  expect_identical(2 * x, new_rvar(x_array * 2))
-  expect_identical(x * y, new_rvar(x_array * y_array))
+  expect_equal(x * 2, new_rvar(x_array * 2))
+  expect_equal(2 * x, new_rvar(x_array * 2))
+  expect_equal(x * y, new_rvar(x_array * y_array))
 
-  expect_identical(x / 2, new_rvar(x_array / 2))
-  expect_identical(2 / x, new_rvar(2 / x_array))
-  expect_identical(x / y, new_rvar(x_array / y_array))
+  expect_equal(x / 2, new_rvar(x_array / 2))
+  expect_equal(2 / x, new_rvar(2 / x_array))
+  expect_equal(x / y, new_rvar(x_array / y_array))
 
-  expect_identical(x ^ 2, new_rvar((x_array) ^ 2))
-  expect_identical(2 ^ x, new_rvar(2 ^ (x_array)))
-  expect_identical(x ^ y, new_rvar(x_array ^ y_array))
+  expect_equal(x ^ 2, new_rvar((x_array) ^ 2))
+  expect_equal(2 ^ x, new_rvar(2 ^ (x_array)))
+  expect_equal(x ^ y, new_rvar(x_array ^ y_array))
 
   # ensure broadcasting of constants retains shape
   z2 <- new_rvar(array(1, dim = c(1,1)))
@@ -42,13 +42,13 @@ test_that("logical operators work", {
   x = as_rvar(x_array)
   y = as_rvar(y_array)
 
-  expect_identical(x | y_array, as_rvar(x_array | y_array))
-  expect_identical(y_array | x, as_rvar(x_array | y_array))
-  expect_identical(x | y, as_rvar(x_array | y_array))
+  expect_equal(x | y_array, as_rvar(x_array | y_array))
+  expect_equal(y_array | x, as_rvar(x_array | y_array))
+  expect_equal(x | y, as_rvar(x_array | y_array))
 
-  expect_identical(x & y_array, as_rvar(x_array & y_array))
-  expect_identical(y_array & x, as_rvar(x_array & y_array))
-  expect_identical(x & y, as_rvar(x_array & y_array))
+  expect_equal(x & y_array, as_rvar(x_array & y_array))
+  expect_equal(y_array & x, as_rvar(x_array & y_array))
+  expect_equal(x & y, as_rvar(x_array & y_array))
 })
 
 test_that("comparison operators work", {
@@ -57,29 +57,29 @@ test_that("comparison operators work", {
   y_array = array(c(2:13,12:1), dim = c(4,2,3))
   y = new_rvar(y_array)
 
-  expect_identical(x < 5, new_rvar(x_array < 5))
-  expect_identical(5 < x, new_rvar(5 < x_array))
-  expect_identical(x < y, new_rvar(x_array < y_array))
+  expect_equal(x < 5, new_rvar(x_array < 5))
+  expect_equal(5 < x, new_rvar(5 < x_array))
+  expect_equal(x < y, new_rvar(x_array < y_array))
 
-  expect_identical(x <= 5, new_rvar(x_array <= 5))
-  expect_identical(5 <= x, new_rvar(5 <= x_array))
-  expect_identical(x <= y, new_rvar(x_array <= y_array))
+  expect_equal(x <= 5, new_rvar(x_array <= 5))
+  expect_equal(5 <= x, new_rvar(5 <= x_array))
+  expect_equal(x <= y, new_rvar(x_array <= y_array))
 
-  expect_identical(x > 5, new_rvar(x_array > 5))
-  expect_identical(5 > x, new_rvar(5 > x_array))
-  expect_identical(x > y, new_rvar(x_array > y_array))
+  expect_equal(x > 5, new_rvar(x_array > 5))
+  expect_equal(5 > x, new_rvar(5 > x_array))
+  expect_equal(x > y, new_rvar(x_array > y_array))
 
-  expect_identical(x >= 5, new_rvar(x_array >= 5))
-  expect_identical(5 >= x, new_rvar(5 >= x_array))
-  expect_identical(x >= y, new_rvar(x_array >= y_array))
+  expect_equal(x >= 5, new_rvar(x_array >= 5))
+  expect_equal(5 >= x, new_rvar(5 >= x_array))
+  expect_equal(x >= y, new_rvar(x_array >= y_array))
 
-  expect_identical(x == 5, new_rvar(x_array == 5))
-  expect_identical(5 == x, new_rvar(5 == x_array))
-  expect_identical(x == y, new_rvar(x_array == y_array))
+  expect_equal(x == 5, new_rvar(x_array == 5))
+  expect_equal(5 == x, new_rvar(5 == x_array))
+  expect_equal(x == y, new_rvar(x_array == y_array))
 
-  expect_identical(x != 5, new_rvar(x_array != 5))
-  expect_identical(5 != x, new_rvar(5 != x_array))
-  expect_identical(x != y, new_rvar(x_array != y_array))
+  expect_equal(x != 5, new_rvar(x_array != 5))
+  expect_equal(5 != x, new_rvar(5 != x_array))
+  expect_equal(x != y, new_rvar(x_array != y_array))
 })
 
 test_that("functions in the Math generic with extra arguments work", {
@@ -131,7 +131,7 @@ test_that("matrix multiplication works", {
     x_array[3,,] %*% y_array[3,,],
     x_array[4,,] %*% y_array[4,,]
   ))
-  expect_identical(x %**% y, xy_ref)
+  expect_equal(x %**% y, xy_ref)
 
 
   x_array = array(1:6, dim = c(2,3))
@@ -143,20 +143,20 @@ test_that("matrix multiplication works", {
     x_array[1,] %*% y_array[1,],
     x_array[2,] %*% y_array[2,]
   ))
-  expect_identical(x %**% y, xy_ref)
+  expect_equal(x %**% y, xy_ref)
 
   # automatic promotion to row/col vector of numeric vectors
   x_meany_ref = new_rvar(abind::abind(along = 0,
     x_array[1,] %*% colMeans(y_array),
     x_array[2,] %*% colMeans(y_array)
   ))
-  expect_identical(x %**% colMeans(y_array), x_meany_ref)
+  expect_equal(x %**% colMeans(y_array), x_meany_ref)
 
   meanx_y_ref = new_rvar(abind::abind(along = 0,
     colMeans(x_array) %*% y_array[1,],
     colMeans(x_array) %*% y_array[2,]
   ))
-  expect_identical(colMeans(x_array) %**% y, meanx_y_ref)
+  expect_equal(colMeans(x_array) %**% y, meanx_y_ref)
 
   # dimension name preservation
   m1 <- as_rvar(diag(1:3))

--- a/tests/testthat/test-rvar-rfun.R
+++ b/tests/testthat/test-rvar-rfun.R
@@ -10,7 +10,7 @@ test_that("rdo works", {
     x_array[3,,] %*% y_array[3,,],
     x_array[4,,] %*% y_array[4,,]
   ))
-  expect_identical(rdo(x %*% y), xy_ref)
+  expect_equal(rdo(x %*% y), xy_ref)
 })
 
 test_that("rfun works", {
@@ -25,7 +25,7 @@ test_that("rfun works", {
     x_array[3,,] %*% y_array[3,,],
     x_array[4,,] %*% y_array[4,,]
   ))
-  expect_identical(rfun(function(a,b) a %*% b)(x, y), xy_ref)
+  expect_equal(rfun(function(a,b) a %*% b)(x, y), xy_ref)
 })
 
 test_that("rvar_rng works", {

--- a/tests/testthat/test-rvar-slice.R
+++ b/tests/testthat/test-rvar-slice.R
@@ -14,8 +14,8 @@ test_that("indexing with [[ works on a vector", {
   x_array_ref = x_array
   dimnames(x_array_ref) <- NULL
 
-  expect_identical(x[[3]], new_rvar(x_array_ref[,3, drop = FALSE]))
-  expect_identical(x[["a2"]], new_rvar(x_array_ref[,2, drop = FALSE]))
+  expect_equal(x[[3]], new_rvar(x_array_ref[,3, drop = FALSE]))
+  expect_equal(x[["a2"]], new_rvar(x_array_ref[,2, drop = FALSE]))
 
   expect_error(x[[]])
   expect_error(x[[NA]])
@@ -42,9 +42,9 @@ test_that("indexing with [[ works on a matrix", {
   x_array_ref = x_array
   dim(x_array_ref) <- c(2,12)
 
-  expect_identical(x[[2]], new_rvar(x_array_ref[,2, drop = TRUE]))
-  expect_identical(x[[12]], new_rvar(x_array_ref[,12, drop = TRUE]))
-  expect_identical(x[[2,3]], new_rvar(x_array[,2,3, drop = TRUE]))
+  expect_equal(x[[2]], new_rvar(x_array_ref[,2, drop = TRUE]))
+  expect_equal(x[[12]], new_rvar(x_array_ref[,12, drop = TRUE]))
+  expect_equal(x[[2,3]], new_rvar(x_array[,2,3, drop = TRUE]))
 
   # invalid indexing should result in errors
   expect_error(x[[1,]])
@@ -68,19 +68,19 @@ test_that("assignment with [[ works", {
   )
   x = new_rvar(x_array)
 
-  expect_identical(
+  expect_equal(
     {x2 <- x; x2[[2]] <- 1; x2},
     new_rvar({xr <- x_array; xr[,2,1] <- 1; xr})
   )
-  expect_identical(
+  expect_equal(
     {x2 <- x; x2[[12]] <- 1; x2},
     new_rvar({xr <- x_array; xr[,4,3] <- 1; xr})
   )
-  expect_identical(
+  expect_equal(
     {x2 <- x; x2[[12]] <- new_rvar(c(1,2)); x2},
     new_rvar({xr <- x_array; xr[,4,3] <- c(1,2); xr})
   )
-  expect_identical(
+  expect_equal(
     {x2 <- x; x2[["a2","b3"]] <- new_rvar(c(1,2)); x2},
     new_rvar({xr <- x_array; xr[,2,3] <- c(1,2); xr})
   )
@@ -100,33 +100,33 @@ test_that("indexing with [ works on a vector", {
   x_array = array(1:20, dim = c(4,5), dimnames = list(A = paste0("a", 1:4), NULL))
   x = rvar_from_array(x_array)
 
-  expect_identical(x[], x)
+  expect_equal(x[], x)
 
-  expect_identical(x[3], rvar_from_array(x_array[3,, drop = FALSE]))
-  expect_identical(x["a2"], rvar_from_array(x_array["a2",, drop = FALSE]))
-  expect_identical(x[c(1,3)], rvar_from_array(x_array[c(1,3),, drop = FALSE]))
-  expect_identical(x[c("a2","a4")], rvar_from_array(x_array[c("a2","a4"),, drop = FALSE]))
+  expect_equal(x[3], rvar_from_array(x_array[3,, drop = FALSE]))
+  expect_equal(x["a2"], rvar_from_array(x_array["a2",, drop = FALSE]))
+  expect_equal(x[c(1,3)], rvar_from_array(x_array[c(1,3),, drop = FALSE]))
+  expect_equal(x[c("a2","a4")], rvar_from_array(x_array[c("a2","a4"),, drop = FALSE]))
 
-  expect_identical(x[c(-1,-3)], rvar_from_array(x_array[c(-1,-3),, drop = FALSE]))
+  expect_equal(x[c(-1,-3)], rvar_from_array(x_array[c(-1,-3),, drop = FALSE]))
 
-  expect_identical(x[TRUE], rvar_from_array(x_array[TRUE,, drop = FALSE]))
-  expect_identical(x[c(TRUE,FALSE)], rvar_from_array(x_array[c(TRUE,FALSE),, drop = FALSE]))
-  expect_identical(x[c(TRUE,FALSE,TRUE)], rvar_from_array(x_array[c(TRUE,FALSE,TRUE),, drop = FALSE]))
-  expect_identical(x[c(TRUE,FALSE,FALSE,TRUE)], rvar_from_array(x_array[c(TRUE,FALSE,FALSE,TRUE),, drop = FALSE]))
+  expect_equal(x[TRUE], rvar_from_array(x_array[TRUE,, drop = FALSE]))
+  expect_equal(x[c(TRUE,FALSE)], rvar_from_array(x_array[c(TRUE,FALSE),, drop = FALSE]))
+  expect_equal(x[c(TRUE,FALSE,TRUE)], rvar_from_array(x_array[c(TRUE,FALSE,TRUE),, drop = FALSE]))
+  expect_equal(x[c(TRUE,FALSE,FALSE,TRUE)], rvar_from_array(x_array[c(TRUE,FALSE,FALSE,TRUE),, drop = FALSE]))
 
   # dropping should preserve names (hence the drop = FALSE on x_array for this test)
-  expect_identical(x["a1", drop = TRUE], rvar_from_array(x_array["a1",, drop = FALSE]))
-  expect_identical(x[1:2, drop = TRUE], rvar_from_array(x_array[1:2,, drop = FALSE]))
+  expect_equal(x["a1", drop = TRUE], rvar_from_array(x_array["a1",, drop = FALSE]))
+  expect_equal(x[1:2, drop = TRUE], rvar_from_array(x_array[1:2,, drop = FALSE]))
 
   # indexing beyond the end of the array should result in NAs, to mimic normal vector indexing
-  expect_identical(x[c(4,5)], rvar_from_array(x_array[c(4,NA_integer_),, drop = FALSE]))
-  expect_identical(x[c(8,9)], rvar_from_array(x_array[c(NA_integer_,NA_integer_),, drop = FALSE]))
+  expect_equal(x[c(4,5)], rvar_from_array(x_array[c(4,NA_integer_),, drop = FALSE]))
+  expect_equal(x[c(8,9)], rvar_from_array(x_array[c(NA_integer_,NA_integer_),, drop = FALSE]))
 
-  expect_identical(x[NA], rvar_from_array(x_array[NA,, drop = FALSE]))
-  expect_identical(x[NA_integer_], rvar_from_array(x_array[NA_integer_,, drop = FALSE]))
-  expect_identical(x[rep(NA_integer_,7)], rvar_from_array(x_array[rep(NA_integer_,7),, drop = FALSE]))
+  expect_equal(x[NA], rvar_from_array(x_array[NA,, drop = FALSE]))
+  expect_equal(x[NA_integer_], rvar_from_array(x_array[NA_integer_,, drop = FALSE]))
+  expect_equal(x[rep(NA_integer_,7)], rvar_from_array(x_array[rep(NA_integer_,7),, drop = FALSE]))
 
-  expect_identical(x[NULL], new_rvar())
+  expect_equal(x[NULL], new_rvar())
 
   expect_error(x[1,1])
 
@@ -143,46 +143,46 @@ test_that("indexing with [ works on an array", {
   )
   x = rvar_from_array(x_array)
 
-  expect_identical(x[], x)
+  expect_equal(x[], x)
 
-  expect_identical(x[2], rvar_from_array(array(x_array[2,1,], dim = c(1,2))))
-  expect_identical(x[2,], rvar_from_array(x_array[2,,, drop = FALSE]))
-  expect_identical(x["a2",], rvar_from_array(x_array["a2",,, drop = FALSE]))
-  expect_identical(x[c(1,2)], rvar_from_array(array(x_array[c(1,2),1,], dim = c(2,2))))
-  expect_identical(x[c(1,2),], rvar_from_array(x_array[c(1,2),,, drop = FALSE]))
-  expect_identical(x[,c(1,3)], rvar_from_array(x_array[,c(1,3),, drop = FALSE]))
-  expect_identical(x[,c("b2","b3")], rvar_from_array(x_array[,c("b2","b3"),, drop = FALSE]))
+  expect_equal(x[2], rvar_from_array(array(x_array[2,1,], dim = c(1,2))))
+  expect_equal(x[2,], rvar_from_array(x_array[2,,, drop = FALSE]))
+  expect_equal(x["a2",], rvar_from_array(x_array["a2",,, drop = FALSE]))
+  expect_equal(x[c(1,2)], rvar_from_array(array(x_array[c(1,2),1,], dim = c(2,2))))
+  expect_equal(x[c(1,2),], rvar_from_array(x_array[c(1,2),,, drop = FALSE]))
+  expect_equal(x[,c(1,3)], rvar_from_array(x_array[,c(1,3),, drop = FALSE]))
+  expect_equal(x[,c("b2","b3")], rvar_from_array(x_array[,c("b2","b3"),, drop = FALSE]))
 
-  expect_identical(x[,c(-1,-3)], rvar_from_array(x_array[,c(-1,-3),, drop = FALSE]))
+  expect_equal(x[,c(-1,-3)], rvar_from_array(x_array[,c(-1,-3),, drop = FALSE]))
 
-  expect_identical(x[TRUE], rvar_from_array(array(x_array, dim = c(12,2))))
-  expect_identical(x[c(TRUE,FALSE)], rvar_from_array(array(x_array, dim = c(12,2))[c(TRUE,FALSE),]))
-  expect_identical(x[c(TRUE,FALSE,TRUE)], rvar_from_array(array(x_array, dim = c(12,2))[c(TRUE,FALSE,TRUE),]))
-  expect_identical(x[c(TRUE,FALSE,FALSE,TRUE)], rvar_from_array(array(x_array, dim = c(12,2))[c(TRUE,FALSE,FALSE,TRUE),]))
+  expect_equal(x[TRUE], rvar_from_array(array(x_array, dim = c(12,2))))
+  expect_equal(x[c(TRUE,FALSE)], rvar_from_array(array(x_array, dim = c(12,2))[c(TRUE,FALSE),]))
+  expect_equal(x[c(TRUE,FALSE,TRUE)], rvar_from_array(array(x_array, dim = c(12,2))[c(TRUE,FALSE,TRUE),]))
+  expect_equal(x[c(TRUE,FALSE,FALSE,TRUE)], rvar_from_array(array(x_array, dim = c(12,2))[c(TRUE,FALSE,FALSE,TRUE),]))
 
-  expect_identical(x[TRUE,], rvar_from_array(x_array[TRUE,,, drop = FALSE]))
-  expect_identical(x[c(TRUE,FALSE),], rvar_from_array(x_array[c(TRUE,FALSE),,, drop = FALSE]))
-  expect_identical(x[c(TRUE,FALSE,TRUE),], rvar_from_array(x_array[c(TRUE,FALSE,TRUE),,, drop = FALSE]))
-  expect_identical(x[c(TRUE,FALSE,FALSE,TRUE),], rvar_from_array(x_array[c(TRUE,FALSE,FALSE,TRUE),,, drop = FALSE]))
+  expect_equal(x[TRUE,], rvar_from_array(x_array[TRUE,,, drop = FALSE]))
+  expect_equal(x[c(TRUE,FALSE),], rvar_from_array(x_array[c(TRUE,FALSE),,, drop = FALSE]))
+  expect_equal(x[c(TRUE,FALSE,TRUE),], rvar_from_array(x_array[c(TRUE,FALSE,TRUE),,, drop = FALSE]))
+  expect_equal(x[c(TRUE,FALSE,FALSE,TRUE),], rvar_from_array(x_array[c(TRUE,FALSE,FALSE,TRUE),,, drop = FALSE]))
 
   # dropping works
-  expect_identical(x["a1",, drop = TRUE], rvar_from_array(x_array["a1",,, drop = TRUE]))
-  expect_identical(x[1:2,, drop = TRUE], rvar_from_array(x_array[1:2,,, drop = TRUE]))
-  expect_identical(x[1,2, drop = TRUE], rvar_from_array(array(x_array[1,2,], dim = c(1,2))))
-  expect_identical(x[1,1:2, drop = TRUE], rvar_from_array(x_array[1,1:2,, drop = TRUE]))
+  expect_equal(x["a1",, drop = TRUE], rvar_from_array(x_array["a1",,, drop = TRUE]))
+  expect_equal(x[1:2,, drop = TRUE], rvar_from_array(x_array[1:2,,, drop = TRUE]))
+  expect_equal(x[1,2, drop = TRUE], rvar_from_array(array(x_array[1,2,], dim = c(1,2))))
+  expect_equal(x[1,1:2, drop = TRUE], rvar_from_array(x_array[1,1:2,, drop = TRUE]))
 
   # indexing beyond the end of the array should result in NAs, to mimic normal vector indexing
-  expect_identical(x[c(4,25)], rvar_from_array(array(x_array[c(4,NA_integer_),1,], dim = c(2,2))))
-  expect_identical(x[c(4,5),], rvar_from_array(x_array[c(4,NA_integer_),,, drop = FALSE]))
-  expect_identical(x[c(8,9),], rvar_from_array(x_array[c(NA_integer_,NA_integer_),,, drop = FALSE]))
+  expect_equal(x[c(4,25)], rvar_from_array(array(x_array[c(4,NA_integer_),1,], dim = c(2,2))))
+  expect_equal(x[c(4,5),], rvar_from_array(x_array[c(4,NA_integer_),,, drop = FALSE]))
+  expect_equal(x[c(8,9),], rvar_from_array(x_array[c(NA_integer_,NA_integer_),,, drop = FALSE]))
 
-  expect_identical(x[NA], rvar_from_array(array(x_array[NA,,], dim = c(12,2))))
-  expect_identical(x[NA,], rvar_from_array(x_array[NA,,, drop = FALSE]))
-  expect_identical(x[NA_integer_], rvar_from_array(array(c(NA_integer_,NA_integer_), dim = c(1,2))))
-  expect_identical(x[NA_integer_,], rvar_from_array(x_array[NA_integer_,,, drop = FALSE]))
-  expect_identical(x[rep(NA_integer_,7)], rvar_from_array(array(rep(NA_integer_,14), dim = c(7,2))))
+  expect_equal(x[NA], rvar_from_array(array(x_array[NA,,], dim = c(12,2))))
+  expect_equal(x[NA,], rvar_from_array(x_array[NA,,, drop = FALSE]))
+  expect_equal(x[NA_integer_], rvar_from_array(array(c(NA_integer_,NA_integer_), dim = c(1,2))))
+  expect_equal(x[NA_integer_,], rvar_from_array(x_array[NA_integer_,,, drop = FALSE]))
+  expect_equal(x[rep(NA_integer_,7)], rvar_from_array(array(rep(NA_integer_,14), dim = c(7,2))))
 
-  expect_identical(x[NULL], new_rvar())
+  expect_equal(x[NULL], new_rvar())
 
   # logical index the length of the array works
   flat_index <- c(
@@ -209,19 +209,19 @@ test_that("assignment with [ works", {
   )
   x = new_rvar(x_array)
 
-  expect_identical(
+  expect_equal(
     {x2 <- x; x2[2,1] <- 1; x2},
     new_rvar({xr <- x_array; xr[,2,1] <- 1; xr})
   )
-  expect_identical(
+  expect_equal(
     {x2 <- x; x2[2,] <- 1; x2},
     new_rvar({xr <- x_array; xr[,2,] <- 1; xr})
   )
-  expect_identical(
+  expect_equal(
     {x2 <- x; x2[,2] <- new_rvar(c(1,2)); x2},
     new_rvar({xr <- x_array; xr[,,2] <- c(1,2); xr})
   )
-  expect_identical(
+  expect_equal(
     {x2 <- x; x2["a2","b3"] <- new_rvar(c(1,2)); x2},
     new_rvar({xr <- x_array; xr[,2,3] <- c(1,2); xr})
   )


### PR DESCRIPTION
This is a stop-gap measure to improve performance on some operations when `rvar`s are used with `vctrs` functions, which generally comes up when `rvar`s are put into `tibble`s. It should not affect the output of any operations, just speed. No need to merge before CRAN if that ship has already sailed, but I figured I would submit this now since it gets it off my plate :).

For more info see r-lib/vctrs#1411

Basically: several `vctrs` functions call `vec_proxy()`, which must return a "proxy" for the vector as an "elementary" vector (some kind of object consisting of base lists, vectors, or data.frames) that can be sliced in a manner respecting the semantics of the object. Which in our case basically means returning a list indexed by the first index of the `rvar` (i.e. the second index of the internal draws array). Generating this proxy is an operation with time proportional to the vector size. This is problematic when that proxy is then used by operations that should be constant time (like `vec_slice()`), as this increases the computational complexity of algorithms using those functions, sometimes to disastrous effect. E.g. in the example I gave in r-lib/vctrs#1411, `split()` on a tibble with an `rvar` column can be orders of magnitude slower than `split()` on a data.frame with an `rvar` column.

This PR adds a simple cache of the proxy to an `rvar` so that operations that repeatedly call `vec_proxy()` only incur the cost of calculating the proxy once. I believe I identified all cases where the cache should be invalidated (basically, any use of `draws_of()<-` or operations that change the number of chains should invalidate this cache).