### PR TITLE
Cleanup the mention of posterior on stan-dev/r-packages repo

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -58,13 +58,7 @@ You can install the latest official release version via
 install.packages("posterior")
 ```
 
-Alternatively, you can install binaries of the current development version via
-
-```{r install_mc_stan, eval=FALSE}
-install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-```
-
-or directly build the package from GitHub via
+or build the developmental version directly from GitHub via
 
 ```{r install_github, eval=FALSE}
 # install.packages("remotes")

--- a/README.md
+++ b/README.md
@@ -43,13 +43,6 @@ You can install the latest official release version via
 install.packages("posterior")
 ```
 
-Alternatively, you can install binaries of the current development
-version via
-
-``` r
-install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-```
-
 or directly build the package from GitHub via
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can install the latest official release version via
 install.packages("posterior")
 ```
 
-or directly build the package from GitHub via
+or build the developmental version directly from GitHub via
 
 ``` r
 # install.packages("remotes")
@@ -293,12 +293,12 @@ x4 <- bind_draws(x1, x3, along = "variable")
 print(x4)
 #> # A draws_matrix: 5 iterations, 1 chains, and 3 variables
 #>     variable
-#> draw  alpha beta theta
-#>    1  0.240    1  0.59
-#>    2  0.232    1  0.25
-#>    3 -1.234    1  0.70
-#>    4  0.479    1  1.41
-#>    5  0.013    1  1.28
+#> draw alpha beta theta
+#>    1 -0.82    1  0.54
+#>    2  0.53    1  0.54
+#>    3 -0.79    1  0.38
+#>    4  0.92    1  0.58
+#>    5 -0.17    1  0.17
 ```
 
 Or, we can bind `x1` and `x2` together along the `'draw'` dimension:
@@ -308,17 +308,17 @@ x5 <- bind_draws(x1, x2, along = "draw")
 print(x5)
 #> # A draws_matrix: 10 iterations, 1 chains, and 2 variables
 #>     variable
-#> draw   alpha beta
-#>   1   0.2400    1
-#>   2   0.2319    1
-#>   3  -1.2345    1
-#>   4   0.4795    1
-#>   5   0.0134    1
-#>   6  -1.0251    2
-#>   7  -1.9515    2
-#>   8  -0.0013    2
-#>   9   1.6684    2
-#>   10  0.2678    2
+#> draw  alpha beta
+#>   1  -0.820    1
+#>   2   0.527    1
+#>   3  -0.789    1
+#>   4   0.925    1
+#>   5  -0.169    1
+#>   6  -0.193    2
+#>   7   1.535    2
+#>   8   0.502    2
+#>   9  -0.207    2
+#>   10 -0.085    2
 ```
 
 As with all **posterior** methods, `bind_draws` can be used with all
@@ -337,27 +337,27 @@ x <- as_draws_matrix(x)
 print(x)
 #> # A draws_matrix: 10 iterations, 1 chains, and 5 variables
 #>     variable
-#> draw     V1     V2      V3     V4    V5
-#>   1  -0.382 -0.429  0.1463  0.762  2.33
-#>   2  -0.160 -0.211  0.9480 -0.760  1.11
-#>   3  -0.048  0.085  0.5779 -0.627 -0.88
-#>   4   0.513  1.053 -0.7525  1.033 -1.09
-#>   5   1.455 -0.779  1.4205 -1.766  0.16
-#>   6   0.019 -1.131  0.0088 -0.094  0.54
-#>   7   0.767 -1.511  0.7245  0.843  0.28
-#>   8  -0.953 -0.200  1.9397  0.520 -0.58
-#>   9   1.173 -0.325 -0.4821  0.948  1.14
-#>   10  0.873  0.486  1.4913 -0.693  1.02
+#> draw     V1     V2     V3      V4     V5
+#>   1  -0.203  0.616 -1.770 -0.4751 -0.931
+#>   2   0.077  1.060  0.664  0.3097  1.492
+#>   3  -1.733 -0.511  0.215 -0.4082  0.478
+#>   4  -1.127 -0.084  0.039 -0.0935  1.517
+#>   5  -2.102 -0.152  2.204  0.1133 -0.815
+#>   6  -0.304  0.502 -0.090 -0.1632  1.528
+#>   7  -0.802 -1.780  0.416  0.0023  0.265
+#>   8  -0.459  0.804  0.350 -0.2718  1.313
+#>   9   1.116 -2.127 -1.598 -0.7790  0.038
+#>   10 -1.033 -0.694  0.673 -0.0686 -1.437
 
 summarise_draws(x, "mean", "sd", "median", "mad")
 #> # A tibble: 5 x 5
-#>   variable    mean    sd median   mad
-#>   <chr>      <dbl> <dbl>  <dbl> <dbl>
-#> 1 V1        0.326  0.755  0.266 0.822
-#> 2 V2       -0.296  0.747 -0.268 0.641
-#> 3 V3        0.602  0.879  0.651 1.05 
-#> 4 V4        0.0166 0.949  0.213 1.15 
-#> 5 V5        0.403  1.06   0.412 1.06
+#>   variable   mean    sd median   mad
+#>   <chr>     <dbl> <dbl>  <dbl> <dbl>
+#> 1 V1       -0.657 0.924 -0.631 0.685
+#> 2 V2       -0.237 1.07  -0.118 1.00 
+#> 3 V3        0.110 1.14   0.283 0.559
+#> 4 V4       -0.183 0.314 -0.128 0.285
+#> 5 V5        0.345 1.12   0.371 1.68
 ```
 
 Instead of `as_draws_matrix()` we also could have just used

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -79,7 +79,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -132,19 +132,19 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://twitter.com/mcmc_stan">
-    <span class="fa fa-twitter"></span>
+    <span class="fas fa-twitter"></span>
      
   </a>
 </li>
 <li>
   <a href="https://github.com/stan-dev/posterior">
-    <span class="fa fa-github"></span>
+    <span class="fas fa-github"></span>
      
   </a>
 </li>
 <li>
   <a href="https://discourse.mc-stan.org/">
-    <span class="fa fa-users"></span>
+    <span class="fas fa-users"></span>
      
   </a>
 </li>

--- a/docs/articles/posterior.html
+++ b/docs/articles/posterior.html
@@ -39,7 +39,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -92,19 +92,19 @@
 <ul class="nav navbar-nav navbar-right">
 <li>
   <a href="https://twitter.com/mcmc_stan">
-    <span class="fa fa-twitter"></span>
+    <span class="fas fa-twitter"></span>
      
   </a>
 </li>
 <li>
   <a href="https://github.com/stan-dev/posterior">
-    <span class="fa fa-github"></span>
+    <span class="fas fa-github"></span>
      
   </a>
 </li>
 <li>
   <a href="https://discourse.mc-stan.org/">
-    <span class="fa fa-users"></span>
+    <span class="fas fa-users"></span>
      
   </a>
 </li>
@@ -118,7 +118,7 @@
 
       
 
-      </header><script src="posterior_files/header-attrs-2.9/header-attrs.js"></script><div class="row">
+      </header><script src="posterior_files/header-attrs-2.8/header-attrs.js"></script><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
       <h1 data-toc-skip>The posterior R package</h1>
@@ -146,9 +146,9 @@
 <div id="installation" class="section level2">
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
-<p>The package is not on CRAN yet, but you can install the latest beta release version via</p>
+<p>You can install the latest official release version via</p>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="st">"posterior"</span>, repos <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="st">"https://mc-stan.org/r-packages/"</span>, <span class="fu"><a href="https://rdrr.io/r/base/options.html">getOption</a></span><span class="op">(</span><span class="st">"repos"</span><span class="op">)</span><span class="op">)</span><span class="op">)</span></code></pre></div>
+<code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="st">"posterior"</span><span class="op">)</span></code></pre></div>
 <p>or the latest development version from GitHub via</p>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># install.packages("remotes")</span>
@@ -285,17 +285,17 @@
 <span class="fu"><a href="https://rdrr.io/r/base/print.html">print</a></span><span class="op">(</span><span class="va">x</span><span class="op">)</span></code></pre></div>
 <pre><code>## # A draws_matrix: 10 iterations, 1 chains, and 5 variables
 ##     variable
-## draw    V1    V2     V3     V4    V5
-##   1   0.29 -0.80 -0.884 -1.179 -0.34
-##   2  -1.31  1.11  0.364 -1.202 -0.50
-##   3   1.09  0.40  0.298  1.373  0.90
-##   4   0.51 -0.71 -0.023 -0.086 -0.43
-##   5  -0.56 -0.61  0.614 -0.089  1.19
-##   6   0.93 -0.82 -1.254 -1.884 -1.17
-##   7   1.30  1.77  1.318 -0.831  0.81
-##   8  -0.18  1.21 -0.209 -0.756  0.60
-##   9   1.16 -1.22  0.208  0.291 -0.29
-##   10  0.13  0.53  0.468  1.099  1.37</code></pre>
+## draw    V1    V2    V3     V4     V5
+##   1  -2.10 -0.71  1.38  2.183  0.081
+##   2  -0.87 -0.47 -0.28  0.665  1.820
+##   3  -1.09  0.20  0.79 -0.125  2.872
+##   4  -1.94  0.36 -0.29 -0.611  0.389
+##   5  -1.80  1.82 -1.08  1.230 -1.899
+##   6  -0.79  0.93  0.17 -0.338 -0.483
+##   7   0.24 -1.78 -0.43 -0.576 -0.424
+##   8   0.57 -0.41 -0.62  2.449  0.921
+##   9  -0.41 -0.69  0.59  0.072 -0.102
+##   10 -0.78  1.30 -0.69  1.245 -1.106</code></pre>
 <p>Because the matrix was converted to a <code>draws_matrix</code>, all of the methods for working with <code>draws</code> objects described in subsequent sections of this vignette will now be available.</p>
 <p>Instead of <code><a href="../reference/draws_matrix.html">as_draws_matrix()</a></code> we also could have just used <code><a href="../reference/draws.html">as_draws()</a></code>, which attempts to find the closest available format to the input object. In this case the result would be a <code>draws_matrix</code> object either way.</p>
 </div>
@@ -308,17 +308,17 @@
 <span class="fu"><a href="https://rdrr.io/r/base/print.html">print</a></span><span class="op">(</span><span class="va">x</span><span class="op">)</span></code></pre></div>
 <pre><code>## # A draws_matrix: 50 iterations, 1 chains, and 2 variables
 ##     variable
-## draw alpha  beta
-##   1   1.52  0.59
-##   2  -0.82 -0.51
-##   3   0.19 -0.46
-##   4  -0.89  0.86
-##   5  -0.44 -0.86
-##   6  -1.39  0.35
-##   7   0.26  0.96
-##   8  -0.19 -1.23
-##   9  -0.69 -0.26
-##   10  0.87 -0.23
+## draw alpha   beta
+##   1   0.63 -0.043
+##   2  -0.44 -0.494
+##   3   0.56 -1.099
+##   4  -0.68 -1.160
+##   5  -0.35 -0.860
+##   6  -0.88  1.651
+##   7   0.68  0.814
+##   8  -1.32 -0.556
+##   9   0.56  0.214
+##   10 -1.99 -0.562
 ## # ... with 40 more draws</code></pre>
 <p>Analogous functions exist for the other draws formats and are used similarly.</p>
 </div>
@@ -426,11 +426,11 @@
 <pre><code>## # A draws_matrix: 5 iterations, 1 chains, and 3 variables
 ##     variable
 ## draw alpha  beta theta
-##    1 -1.10  0.77  1.21
-##    2  1.36 -0.53  0.56
-##    3  1.14  0.42  0.75
-##    4  2.43  1.16  1.01
-##    5  0.77 -1.58  1.11</code></pre>
+##    1  0.22 -0.93  0.42
+##    2 -0.24  0.11  1.55
+##    3 -1.17 -0.74  0.51
+##    4 -0.95 -0.74  0.35
+##    5  0.28  0.58  0.62</code></pre>
 <p>Because <code>x1</code> and <code>x2</code> have the same variables, we can bind them along the <code>'draw'</code> dimension to create a single <code>draws_matrix</code> with more draws:</p>
 <div class="sourceCode" id="cb36"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">x5</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/bind_draws.html">bind_draws</a></span><span class="op">(</span><span class="va">x1</span>, <span class="va">x2</span>, along <span class="op">=</span> <span class="st">"draw"</span><span class="op">)</span>
@@ -438,16 +438,16 @@
 <pre><code>## # A draws_matrix: 10 iterations, 1 chains, and 2 variables
 ##     variable
 ## draw alpha  beta
-##   1  -1.10  0.77
-##   2   1.36 -0.53
-##   3   1.14  0.42
-##   4   2.43  1.16
-##   5   0.77 -1.58
-##   6  -0.87  0.48
-##   7   2.42 -0.48
-##   8  -1.73  1.96
-##   9   1.00  0.58
-##   10 -0.36  0.87</code></pre>
+##   1   0.22 -0.93
+##   2  -0.24  0.11
+##   3  -1.17 -0.74
+##   4  -0.95 -0.74
+##   5   0.28  0.58
+##   6   0.36  1.12
+##   7   1.53  1.60
+##   8   0.79  0.36
+##   9   0.46 -1.08
+##   10 -0.17 -1.22</code></pre>
 <p>As with all posterior methods, <code><a href="../reference/bind_draws.html">bind_draws()</a></code> can be used with all draws formats and depending on the format different dimensions are available to bind on. For example, we can bind <code>draws_array</code> objects together by <code>iteration</code>, <code>chain</code>, or <code>variable</code>, but a 2-D <code>draws_matrix</code> with the chains combined can only by bound by <code>draw</code> and <code>variable</code>.</p>
 </div>
 </div>
@@ -533,16 +533,16 @@
 <pre><code>## # A tibble: 10 x 2
 ##    variable weighted_mean
 ##    &lt;chr&gt;            &lt;dbl&gt;
-##  1 mu                4.32
-##  2 tau               4.01
-##  3 theta[1]          6.34
-##  4 theta[2]          5.27
-##  5 theta[3]          2.90
-##  6 theta[4]          4.85
-##  7 theta[5]          3.47
-##  8 theta[6]          4.15
-##  9 theta[7]          6.77
-## 10 theta[8]          5.06</code></pre>
+##  1 mu                4.15
+##  2 tau               4.04
+##  3 theta[1]          6.57
+##  4 theta[2]          5.12
+##  5 theta[3]          2.81
+##  6 theta[4]          4.87
+##  7 theta[5]          3.13
+##  8 theta[6]          4.27
+##  9 theta[7]          6.25
+## 10 theta[8]          4.73</code></pre>
 </div>
 <div id="specifying-functions-using-lambda-like-syntax" class="section level3">
 <h3 class="hasAnchor">

--- a/vignettes/posterior.Rmd
+++ b/vignettes/posterior.Rmd
@@ -27,11 +27,10 @@ from Bayesian models. The primary goals of the package are to:
 
 ## Installation
 
-The package is not on CRAN yet, but you can install the latest beta release 
-version via 
+You can install the latest official release version via
 
 ```{r install, eval=FALSE}
-install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+install.packages("posterior")
 ```
 
 or the latest development version from GitHub via 


### PR DESCRIPTION
#### Summary

With the CRAN release now live, I removed posterior from the Stan r-packages. The command

```r
install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
```

still works, but it does the same as regular install.packages. There is currently no reason to have posterior duplicated in our repository as well. It just duplicates work and will inevitably become out of sync. In the unlikely event we will need to host it again, we can simply add it back. Till then the CRAN + Github install will work just fine.

There was mention of the stan-dev/r-packages in a vignette as well.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)