### PR TITLE
Manually attach/detach caret as needed for rstar

### DIFF
--- a/R/rstar.R
+++ b/R/rstar.R
@@ -95,9 +95,20 @@ rstar <- function(x, split = TRUE,
                   nsimulations = 1000,
                   ...) {
 
-  if (!"caret" %in% .packages()) {
-    stop_no_call("Package 'caret' is required for 'rstar' to work. ",
-          "Please use library(caret) to load the package.")
+  # caret requires itself to be attached to the search list (not just loaded).
+  # To avoid polluting the user's namespace we manually attach caret and its
+  # two hard dependencies (ggplot2 and lattice) if they aren't already attached,
+  # and unload any of them we had to attach when this function exits.
+  loaded_packages <- character()
+  on.exit(for (package in loaded_packages) {
+    detach(paste0("package:", package), character.only = TRUE)
+  })
+  for (package in setdiff(c("ggplot2", "lattice", "caret"), .packages())) {
+    if (!suppressPackageStartupMessages(require(package, character.only = TRUE, quietly = TRUE))) {
+      stop_no_call("Package '", package, "' is required for 'rstar' to work.")
+    }
+    # store in reverse order since we'll unload in reverse
+    loaded_packages <- c(package, loaded_packages)
   }
 
   split <- as_one_logical(split)

--- a/R/rstar.R
+++ b/R/rstar.R
@@ -104,7 +104,7 @@ rstar <- function(x, split = TRUE,
     detach(paste0("package:", package), character.only = TRUE)
   })
   for (package in setdiff(c("ggplot2", "lattice", "caret"), .packages())) {
-    if (!suppressPackageStartupMessages(require(package, character.only = TRUE, quietly = TRUE))) {
+    if (!suppressPackageStartupMessages(get("require")(package, character.only = TRUE, quietly = TRUE))) {
       stop_no_call("Package '", package, "' is required for 'rstar' to work.")
     }
     # store in reverse order since we'll unload in reverse

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,5 +1,4 @@
 library(testthat)
 library(posterior)
-library(caret)
 
 test_check("posterior")

--- a/tests/testthat/test-rstar.R
+++ b/tests/testthat/test-rstar.R
@@ -1,4 +1,3 @@
-require(caret)
 
 test_that("rstar returns reasonable values", {
   x <- example_draws()


### PR DESCRIPTION
I was thinking about the whole caret namespace thing (#164) and realized there's another way to solve it: to attach and detach caret just for the duration of the `rstar()` function if the user does not have it attached already. This PR implements that solution, which makes us no longer dependent on caret changing how it expects users to use it.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)