### PR TITLE
allow as_draws_rvars to accept lists of lists, closes #192

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: posterior
 Title: Tools for Working with Posterior Distributions
-Version: 1.0.1
-Date: 2021-07-14
+Version: 1.0.1.9000
+Date: 2021-08-22
 Authors@R: c(person("Paul-Christian", "Bürkner", email = "paul.buerkner@gmail.com", role = c("aut", "cre")),
              person("Jonah", "Gabry", email = "jsg2201@columbia.edu", role = c("aut")),
-             person("Matthew", "Kay", email = "mjskay@umich.edu", role = c("aut")),
+             person("Matthew", "Kay", email = "mjskay@northwestern.edu", role = c("aut")),
              person("Aki", "Vehtari", email = "Aki.Vehtari@aalto.fi", role = c("aut")),
              person("Måns", "Magnusson", role = c("ctb")),
              person("Rok", "Češnovar", role = c("ctb")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,15 @@
+# posterior 1.0.1.9000
+
+### Bug Fixes
+
+* ensure that `as_draws_rvars()` works on lists of lists (#192)
+
+
 # posterior 1.0.1
 
 * ensure that all unit tests pass on all CRAN environments
 * fix a problem that sometimes lead to `rvar`s being unnecessarily slow (#179)
+
 
 # posterior 1.0.0
 

--- a/R/as_draws_rvars.R
+++ b/R/as_draws_rvars.R
@@ -35,7 +35,11 @@ as_draws_rvars.draws_rvars <- function(x, ...) {
 #' @rdname draws_rvars
 #' @export
 as_draws_rvars.list <- function(x, ...) {
-  .as_draws_rvars(x, ...)
+  if (all(vapply(x, is_rvar, logical(1)))) {
+    .as_draws_rvars(x, ...)
+  } else {
+    as_draws_rvars(as_draws_list(x), ...)
+  }
 }
 
 #' @export

--- a/R/as_draws_rvars.R
+++ b/R/as_draws_rvars.R
@@ -38,7 +38,7 @@ as_draws_rvars.list <- function(x, ...) {
   if (all(vapply(x, is_rvar, logical(1)))) {
     .as_draws_rvars(x, ...)
   } else {
-    as_draws_rvars(as_draws_list(x), ...)
+    NextMethod()
   }
 }
 

--- a/tests/testthat/test-as_draws.R
+++ b/tests/testthat/test-as_draws.R
@@ -321,6 +321,14 @@ test_that("as_draws_rvars correctly reshapes missing, out-of-order, and string a
   expect_equal(as_draws_rvars(as_draws_array(x_rvars2)), x_rvars2)
 })
 
+test_that("as_draws_rvars can accept lists of lists as input", {
+  # for https://github.com/stan-dev/posterior/issues/192
+  draws_list <- as_draws_list(example_draws())
+  list_of_lists <- unclass(draws_list)
+
+  expect_equal(as_draws_rvars(example_draws()), as_draws_rvars(list_of_lists))
+})
+
 test_that("draws_df does not munge variable names", {
   draws_df <- draws_df(`x[1]` = 1:2, `x[2]` = 3:4)
   expect_equal(variables(draws_df), c("x[1]", "x[2]"))


### PR DESCRIPTION
#### Summary

This fixes #192 by falling back to the default list conversion behavior in as_draws_rvars.list() unless the input is a list of rvars.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)