### PR TITLE
Replace fft_next_good_size() by nextn()

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -536,25 +536,6 @@ quantile2.rvar <- function(
 
 # internal ----------------------------------------------------------------
 
-#' Find the optimal next size for the FFT so that a minimum number of zeros
-#' are padded.
-#' @param N length of the sequence over which to apply FFT
-#' @return the optimal next step size as a single integer
-#' @noRd
-fft_next_good_size <- function(N) {
-  if (N <= 2)
-    return(2)
-  while (TRUE) {
-    m <- N
-    while ((m %% 2) == 0) m <- m / 2
-    while ((m %% 3) == 0) m <- m / 3
-    while ((m %% 5) == 0) m <- m / 5
-    if (m <= 1)
-      return(N)
-    N <- N + 1
-  }
-}
-
 #' Autocovariance estimates
 #'
 #' Compute autocovariance estimates for every lag for the specified
@@ -568,7 +549,7 @@ fft_next_good_size <- function(N) {
 autocovariance <- function(x) {
   N <- length(x)
   # zero padding makes fft() much faster when N > 1000
-  M <- fft_next_good_size(N)
+  M <- nextn(N)
   Mt2 <- 2 * M
   yc <- x - mean(x)
   yc <- c(yc, rep.int(0, Mt2 - N))


### PR DESCRIPTION
#### Summary

Drop *fft_next_good_size()* function and replace its uses with *nextn()* from base R (*stats* package).
*nextn()* should be a lot faster and better handle corner cases.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)