### PR TITLE
fix some vector recycling issues with rvar_rng, closes #195

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 * ensure that `as_draws_rvars()` works on lists of lists (#192)
+* fix some vector recycling issues with `rvar_rng` (#195)
 
 
 # posterior 1.0.1

--- a/R/rvar-rfun.R
+++ b/R/rvar-rfun.R
@@ -227,7 +227,7 @@ rdo <- function(expr, dim = NULL, ndraws = NULL) {
 rvar_rng <- function(.f, n, ..., ndraws = NULL) {
   args <- list(...)
 
-  is_rvar_arg <- as.logical(lapply(args, is_rvar))
+  is_rvar_arg <- vapply(args, is_rvar, logical(1))
   rvar_args <- conform_rvar_ndraws_nchains(args[is_rvar_arg])
 
   if (length(rvar_args) < 1) {
@@ -244,12 +244,24 @@ rvar_rng <- function(.f, n, ..., ndraws = NULL) {
       stop_no_call("All arguments to rvar_rng() that are rvars must be single-dimensional (vectors).")
     }
 
-    args[is_rvar_arg] <- lapply(rvar_args, function(x) t(draws_of(x)))
+    args[is_rvar_arg] <- lapply(rvar_args, function(x) as.vector(draws_of(x)))
   }
+
+  # we must manually recycle numeric vector arguments up to the desired number
+  # of draws so that they can be correctly recycled along the draws of any input
+  # rvars. We only convert numeric *vectors*, as (1) scalars can be recycled
+  # as-is and (2) matrices and 2d+ arrays cannot be correctly recycled using R's
+  # recycling rules so they are are typically only used as constant arguments to
+  # random number generator functions (e.g. Sigma for a multivariate normal),
+  # so we don't need to worry about them.
+  is_numeric_vector_arg <-
+    vapply(args, function(x) is.numeric(x) && length(x) > 1 && length(dim(x)) <= 1, logical(1)) &
+    !is_rvar_arg
+  args[is_numeric_vector_arg] <- lapply(args[is_numeric_vector_arg], rep, each = ndraws)
 
   nd <- n * ndraws
   args <- c(n = nd, args)
   result <- do.call(.f, args)
-  dim(result) <- c(n, ndraws)
-  new_rvar(t(result), .nchains = nchains)
+  dim(result) <- c(ndraws, n)
+  new_rvar(result, .nchains = nchains)
 }

--- a/R/rvar-rfun.R
+++ b/R/rvar-rfun.R
@@ -251,7 +251,7 @@ rvar_rng <- function(.f, n, ..., ndraws = NULL) {
   # of draws so that they can be correctly recycled along the draws of any input
   # rvars. We only convert numeric *vectors*, as (1) scalars can be recycled
   # as-is and (2) matrices and 2d+ arrays cannot be correctly recycled using R's
-  # recycling rules so they are are typically only used as constant arguments to
+  # recycling rules so they are typically only used as constant arguments to
   # random number generator functions (e.g. Sigma for a multivariate normal),
   # so we don't need to worry about them.
   is_numeric_vector_arg <-

--- a/tests/testthat/test-rvar-rfun.R
+++ b/tests/testthat/test-rvar-rfun.R
@@ -38,3 +38,30 @@ test_that("rvar_rng works", {
   expect_equal(mean(x), 1:10, tolerance = 0.1)
   expect_equal(apply(draws_of(x), 2, sd), rep(1.7, 10), tolerance = 0.1)
 })
+
+test_that("rvar_rng recycling works with numeric and rvar arguments", {
+  # a fake random number generator that we can use to ensure draws are being
+  # correctly reshaped and lined up
+  rfake = function(n, tens, ones) {
+    rep_len(tens * 10 + ones, length.out = n)
+  }
+
+  # numeric arguments
+  ref <- rvar(array(c(11, 11, 22, 22, 13, 13, 24, 24), dim = c(2,4)))
+  expect_equal(rvar_rng(rfake, 4, 1:2, 1:4, ndraws = 2), ref)
+
+  # mixed numeric and rvar arguments
+  ones <- rvar(array(1:8, dim = c(2,4)))
+  ref <- rvar(array(c(11, 12, 23, 24, 15, 16, 27, 28), dim = c(2,4)))
+  expect_equal(rvar_rng(rfake, 4, 1:2, ones), ref)
+
+  # rvar arguments
+  x <- c(15, 26, 37, 48)
+  expect_equal(rvar_rng(rfake, 1, rvar(1:4), rvar(5:8)), rvar(x))
+  expect_equal(rvar_rng(rfake, 2, rvar(1:4), rvar(5:8)), rvar(array(c(x, x), dim = c(4, 2))))
+
+  tens <- rvar(array(1:4, dim = c(2,2)))
+  ones <- rvar(array(1:8, dim = c(2,4)))
+  ref <- rvar(array(c(11, 22, 33, 44, 15, 26, 37, 48), dim = c(2,4)))
+  expect_equal(rvar_rng(rfake, 4, tens, ones), ref)
+})


### PR DESCRIPTION
#### Summary

This closes #195, which revealed that draws do not always line up properly between parameters in rvar_rng. One of those cases where what I had thought was a nice elegant solution failed in some (fairly important!) corner cases. This PR includes some better tests to cover those corner cases (and some that came up in the process of fixing this).

If anyone cares, in untangling the solution I basically realized that the draws dimension must be first prior to flattening the draws array and passing it to an rng functions in order for R vector recycling to work correctly (really I should have realized this before since I used this fact to implement array broadcasting for rvars in the first place). The upshot though is that some manual recycling must be done on non-rvar input.

Anyway the upshot is I think this is fixed now, but if @martinmodrak or anyone else wants to kick the tires please do.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)