### PR TITLE
if variance is 0, return autocovariance 0

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -548,6 +548,11 @@ quantile2.rvar <- function(
 #' @export
 autocovariance <- function(x) {
   N <- length(x)
+  varx <- var(x)
+  if (varx==0) {
+    # if variance is 0, then all autocovariances are 0
+    return(rep(0, N))
+  }
   # zero padding makes fft() much faster when N > 1000
   M <- nextn(N)
   Mt2 <- 2 * M
@@ -557,7 +562,7 @@ autocovariance <- function(x) {
   ac <- Re(fft(abs(fft(yc))^2, inverse = TRUE)[1:N])
   # use "biased" estimate as recommended by Geyer (1992)
   # direct scaling with var(x) avoids need to compute "mask effect"
-  ac <- ac / ac[1] * var(x) * (N - 1) / N
+  ac <- ac / ac[1] * varx * (N - 1) / N
   ac
 }
 


### PR DESCRIPTION
#### Summary

Fixes #198

If var(x)==0 ,the fix for #126 computed 0/0  and thus returned NA instead of 0 autocovariances.

This PR adds check for var(x)==0 in autocovariance function.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)