### PR TITLE
Keep variable order in subset_draws()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * ensure that `as_draws_rvars()` works on lists of lists (#192)
 * fix some vector recycling issues with `rvar_rng` (#195)
+* ensure that `subset_draws()` respects input variable order, thanks to
+Karl Dunkle Werner and Alexey Stukalov (#188)
 
 ### Other Changes
 

--- a/R/draws-index.R
+++ b/R/draws-index.R
@@ -474,7 +474,7 @@ check_existing_variables <- function(variables, x, regex = FALSE,
 
     # need to use merge for the second join as vector variables may match
     # multiple variables in `x`
-    all_variables_base <- gsub("\\[.*\\]$", "", all_variables)
+    all_variables_base <- gsub("\\[.*\\]$", "", all_variables, perl = TRUE)
     variables_df <- merge(
       # left join seems to rearrange input order, so need to keep it
       # and the order of variables in x so we can restore them later

--- a/R/draws-index.R
+++ b/R/draws-index.R
@@ -478,8 +478,14 @@ check_existing_variables <- function(variables, x, regex = FALSE,
     variables_df <- merge(
       # left join seems to rearrange input order, so need to keep it
       # and the order of variables in x so we can restore them later
-      data.frame(variable = variables, input_order = seq_along(variables), scalar = scalar_variables),
-      data.frame(variable = all_variables_base, vector = all_variables, variable_order = seq_along(all_variables)),
+      data.frame(
+        variable = variables, input_order = seq_along(variables), scalar = scalar_variables,
+        stringsAsFactors = FALSE
+      ),
+      data.frame(
+        variable = all_variables_base, vector = all_variables, variable_order = seq_along(all_variables),
+        stringsAsFactors = FALSE
+      ),
       by = "variable",
       sort = FALSE,
       all.x = TRUE

--- a/tests/testthat/test-subset_draws.R
+++ b/tests/testthat/test-subset_draws.R
@@ -116,7 +116,6 @@ test_that("variables can be subsetted via non-scalar selection", {
 test_that("subset_draws speed is tolerable with many variables", {
   # some machines will be slower and so this test is unreliable on CRAN
   skip_on_cran()
-  skip("Performance is not tolerable")
   x <- as_draws_matrix(matrix(rnorm(10 * 300000), nrow = 10))
   tt <- system.time(x2 <- subset_draws(x, colnames(x)))
   expect_equal(x, x2)

--- a/tests/testthat/test-subset_draws.R
+++ b/tests/testthat/test-subset_draws.R
@@ -116,6 +116,7 @@ test_that("variables can be subsetted via non-scalar selection", {
 test_that("subset_draws speed is tolerable with many variables", {
   # some machines will be slower and so this test is unreliable on CRAN
   skip_on_cran()
+  skip("Performance is not tolerable")
   x <- as_draws_matrix(matrix(rnorm(10 * 300000), nrow = 10))
   tt <- system.time(x2 <- subset_draws(x, colnames(x)))
   expect_equal(x, x2)
@@ -135,6 +136,31 @@ test_that("subset_draws preserves variable order", {
   x <- as_draws_matrix(example_draws())
   x <- subset_draws(x, variable = c("theta[2]", "theta[1]"))
   expect_equal(variables(x), c("theta[2]", "theta[1]"))
+})
+
+test_that("subset_draws preserves variable order with vectors", {
+  x <- as_draws_matrix(example_draws())
+  theta_names <- paste0("theta[", 1:8, "]")
+  # Expect variables to be returned in the order listed:
+  v1 <- variables(subset_draws(x, variable = c("theta", "mu")))
+  expect_equal(v1, c(theta_names, "mu"))
+  v2 <- variables(subset_draws(x, variable = c("mu", "theta")))
+  expect_equal(v2, c("mu", theta_names))
+  v3 <- variables(subset_draws(x, variable = c("mu", "theta", "tau")))
+  expect_equal(v3, c("mu", theta_names, "tau"))
+  # No duplication:
+  v4 <- variables(subset_draws(x, variable = c("mu", "mu", "theta")))
+  expect_equal(v4, c("mu", theta_names))
+  v5 <- variables(subset_draws(x, variable = c("mu", "theta", "theta")))
+  expect_equal(v5, c("mu", theta_names))
+  v6 <- variables(subset_draws(x, variable = c("theta", "mu", "theta")))
+  expect_equal(v6, c(theta_names, "mu"))
+
+  # Output is sorted numerically, not alphabetically
+  x2 <- as_draws_matrix(matrix(rep.int(1, 11 * 3), ncol = 11))
+  colnames(x2) <- paste0("a[",1:11,"]")
+  v7 <- variables(subset_draws(x2, variable = "a"))
+  expect_equal(v7, colnames(x2))
 })
 
 test_that("non-unique subsetting for draws_df same as doing it with draws_list", {


### PR DESCRIPTION
#### Summary

This PR tries to fix #188. The basic approach I took here is to `grep` through the variable names. This is slow, and increases non-linearly in the number of variables, so probably isn't what you actually want to include. Hopefully the test cases are useful.

If you see a way to make this significantly faster, let me know!

I skipped the performance test for now. It takes 11s to run with 10,000 variables (the test requires 300,000 variables in less than a second).




#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)