### PR TITLE
Fix hidden variables in bind_draws_df when binding more than two objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: posterior
 Title: Tools for Working with Posterior Distributions
-Version: 1.1.0
-Date: 2021-09-09
+Version: 1.1.0.9000
+Date: 2021-09-16
 Authors@R: c(person("Paul-Christian", "Bürkner", email = "paul.buerkner@gmail.com", role = c("aut", "cre")),
              person("Jonah", "Gabry", email = "jsg2201@columbia.edu", role = c("aut")),
              person("Matthew", "Kay", email = "mjskay@northwestern.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# posterior 1.1.0.9000
+
+### Bug Fixes
+
+* fix hidden variables in `bind_draws.draws_df` when binding 
+more than two objects thanks to Jouni Helske (#204)
+
+
 # posterior 1.1.0
 
 ### Enhancements

--- a/R/bind_draws.R
+++ b/R/bind_draws.R
@@ -113,18 +113,18 @@ bind_draws.draws_df <- function(x, ..., along = "variable") {
   } else if (along == "chain") {
     check_same_fun_output(dots, variables)
     check_same_fun_output(dots, iteration_ids)
-    nchains <- ulapply(dots, nchains)
+    cumsum_chains <- c(0, cumsum(ulapply(dots, nchains)))
     for (i in seq_along(dots)) {
-      dots[[i]]$.chain <- sum(nchains[i - 1]) + dots[[i]]$.chain
+      dots[[i]]$.chain <- cumsum_chains[i] + dots[[i]]$.chain
       dots[[i]]$.chain <- as.integer(dots[[i]]$.chain)
     }
     out <- do.call(rbind, dots)
   } else if (along == "iteration") {
     check_same_fun_output(dots, variables)
     check_same_fun_output(dots, chain_ids)
-    niterations <- ulapply(dots, niterations)
+    cumsum_iterations <- c(0, cumsum(ulapply(dots, niterations)))
     for (i in seq_along(dots)) {
-      dots[[i]]$.iteration <- sum(niterations[i - 1]) + dots[[i]]$.iteration
+      dots[[i]]$.iteration <- cumsum_iterations[i] + dots[[i]]$.iteration
       dots[[i]]$.iteration <- as.integer(dots[[i]]$.iteration)
     }
     out <- do.call(rbind, dots)

--- a/tests/testthat/test-bind_draws.R
+++ b/tests/testthat/test-bind_draws.R
@@ -98,6 +98,39 @@ test_that("bind_draws works for draws_df objects", {
   expect_equal(draws_new, draws1)
 })
 
+
+test_that("bind_draws works for multiple draws_df objects", {
+
+  draws1 <- as_draws_df(example_draws())
+  draws2 <- subset_draws(draws1, chain = 2)
+  draws3 <-  subset_draws(draws1, chain = 3)
+
+  draws12 <- bind_draws(draws1, draws2, along = "chain")
+  draws123 <- bind_draws(draws12, draws3, along = "chain")
+  draws_all <- bind_draws(draws1, draws2, draws3, along = "chain")
+  expect_equal(draws123, draws_all)
+  expect_equal(nchains(draws_all),
+    nchains(draws1) + nchains(draws2) + nchains(draws3))
+  expect_equal(ndraws(draws_all),
+    ndraws(draws1) + ndraws(draws2) + ndraws(draws3))
+  expect_equal(niterations(draws_all), niterations(draws1))
+  expect_equal(variables(draws_all), variables(draws1))
+
+  draws4 <-  subset_draws(draws1, chain = 4)
+  draws23 <- bind_draws(draws2, draws3, along = "iteration")
+  draws234 <- bind_draws(draws23, draws4, along = "iteration")
+  draws_all <- bind_draws(draws2, draws3, draws4, along = "iteration")
+  expect_equal(draws234, draws_all)
+
+  expect_equal(nchains(draws_all), 1L)
+  expect_equal(niterations(draws_all),
+    niterations(draws2) + niterations(draws3) + niterations(draws4))
+  expect_equal(niterations(draws_all), ndraws(draws_all))
+
+  expect_equal(variables(draws_all), variables(draws2))
+
+})
+
 test_that("bind_draws works for draws_list objects", {
   draws1 <- as_draws_list(example_draws())
   draws2 <- subset_draws(draws1, chain = 2)


### PR DESCRIPTION
#### Summary

Fixes `bind_draws_df` which resulted wrong output for `.chains`, `.iter` and `.draw` columns when binding more than two objects. Earlier output:
```
set.seed(1)
x1d <- draws_df(alpha = 1:3, beta = rnorm(3))
x2d <- draws_df(alpha = 4:6, beta = rnorm(3))
x3d <- draws_df(alpha = 7:9, beta = rnorm(3))
x4d <- draws_df(alpha = 10:12, beta = rnorm(3))

x12d <- bind_draws(x1d, x2d, along = "chain")
d_df <- bind_draws(x12d, x3d, x4d, along = "chain")
print(d_df)
# A draws_df: 6 iterations, 3 chains, and 2 variables
   alpha  beta
1      1 -0.63
2      2  0.18
3      3 -0.84
4     NA    NA
5     NA    NA
6     NA    NA
7      4  1.60
8     10 -0.31
9      5  0.33
10    11  1.51
# ... with 2 more draws
# ... hidden reserved variables {'.chain', '.iteration', '.draw'}
data.frame(d_df)
   alpha       beta .chain .iteration .draw
1      1 -0.6264538      1          1     1
2      2  0.1836433      1          2     2
3      3 -0.8356286      1          3     3
4      4  1.5952808      2          1     7
5      5  0.3295078      2          3     9
6      6 -0.8204684      2          5    11
7      7  0.4874291      3          1    13
8      8  0.7383247      3          2    14
9      9  0.5757814      3          3    15
10    10 -0.3053884      2          2     8
11    11  1.5117812      2          4    10
12    12  0.3898432      2          6    12
```

Fixed version:
```
> d_df
# A draws_df: 3 iterations, 4 chains, and 2 variables
   alpha  beta
1      1 -0.63
2      2  0.18
3      3 -0.84
4      4  1.60
5      5  0.33
6      6 -0.82
7      7  0.49
8      8  0.74
9      9  0.58
10    10 -0.31
# ... with 2 more draws
# ... hidden reserved variables {'.chain', '.iteration', '.draw'}
> data.frame(d_df)
   alpha       beta .chain .iteration .draw
1      1 -0.6264538      1          1     1
2      2  0.1836433      1          2     2
3      3 -0.8356286      1          3     3
4      4  1.5952808      2          1     4
5      5  0.3295078      2          2     5
6      6 -0.8204684      2          3     6
7      7  0.4874291      3          1     7
8      8  0.7383247      3          2     8
9      9  0.5757814      3          3     9
10    10 -0.3053884      4          1    10
11    11  1.5117812      4          2    11
12    12  0.3898432      4          3    12
```

Test that the results are identical with `draws_matrix`:
```
set.seed(1)
x1d <- draws_df(alpha = 1:3, beta = rnorm(3))
x2d <- draws_df(alpha = 4:6, beta = rnorm(3))
x3d <- draws_df(alpha = 7:9, beta = rnorm(3))
x4d <- draws_df(alpha = 10:12, beta = rnorm(3))

x12d <- bind_draws(x1d, x2d, along = "chain")
d_df <- bind_draws(x12d, x3d, x4d, along = "chain")
identical(d_df, bind_draws(x1d, x2d, x3d, x4d, along = "chain"))

set.seed(1)
x1m <- draws_matrix(alpha = 1:3, beta = rnorm(3))
x2m <- draws_matrix(alpha = 4:6, beta = rnorm(3))
x3m <- draws_matrix(alpha = 7:9, beta = rnorm(3))
x4m <- draws_matrix(alpha = 10:12, beta = rnorm(3))

x12m <- bind_draws(x1m, x2m, along = "chain")
d_m <- bind_draws(x12m, x3m, x4m, along = "chain")

identical(d_df, as_draws_df(d_m))
# check also binding along iteration number:
x12d <- bind_draws(x1d, x2d, along = "iteration")
d_df <- bind_draws(x12d, x3d, x4d, along = "iteration")

identical(d_df, bind_draws(x1d, x2d, x3d, x4d, along = "iteration"))
```
#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)