### PR TITLE
fix print.draws_df for objects with unrepaired draws

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,18 @@
 # posterior 1.1.0.9000
 
+### Enhancements
+
+* support casting to/from `rvar` and `distributional::dist_sample` (#109)
+
 ### Bug Fixes
 
 * fix hidden variables in `bind_draws.draws_df` when binding 
 more than two objects thanks to Jouni Helske (#204)
+* fix output of `pillar::glimpse()` when used on a data frame containing 
+`rvar`s (#210)
+* drop `"draws"` and `"draws_df"` classes from `draws_df` objects if meta data
+columns are removed by a `dplyr` operation (#202)
+* fix output of `print.draws_df()` on objects with unrepaired draws (#217)
 
 
 # posterior 1.1.0

--- a/R/print.R
+++ b/R/print.R
@@ -175,7 +175,7 @@ print.draws_df <- function(x, digits = 2,
   seq_variables <- seq_len(min(max_variables, nvariables))
   sel_variables <- sel_variables[seq_variables]
   y <- .subset_draws(
-    x, draw = sel_draws, variable = sel_variables,
+    x[sel_draws,], variable = sel_variables,
     reserved = reserved
   )
   if (!reserved) {

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -106,3 +106,15 @@ test_that("print.draws_rvars handles reserved variables correctly", {
     fixed = TRUE
   )
 })
+
+test_that("print.draws_df correctly handles data frames with unrepaired draws", {
+  x <- as_draws_df(list(x = 1:10, y = 2:11))
+  x_slice <- x[c(1,3,5),]
+  expect_output(
+    print(x_slice),
+"x +y
+1 +1 +2
+2 +3 +4
+3 +5 +6"
+  )
+})


### PR DESCRIPTION
This fixes #217 

It also updates `NEWS.md` with a few entries for recent PRs of mine that I forgot to include previously ;)

Since we already discussed this fix at #217, once the checks pass I will merge this.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)