### PR TITLE
One more test fix for CRAN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 * Correctly transform lists of data.frames into `draws_list` objects.
+* Correctly drop variables on assigning `NULL` in `mutate_variables`. (#222)
 
 
 # posterior 1.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# posterior 1.2.0++
+# posterior 1.2.1
 
 ### Bug Fixes
 

--- a/R/mutate_variables.R
+++ b/R/mutate_variables.R
@@ -92,6 +92,9 @@ mutate_variables.draws_rvars <- function(.x, ...) {
 # evaluate an expression passed to 'mutate_variables' and check its validity
 .mutate_variable <- function(expr, data, env = caller_env()) {
   out <- eval_tidy(expr, data, env)
+  if (is.null(out)) {
+    return(NULL)
+  }
   if (!is.numeric(out)) {
     stop_no_call("{", as_label(expr), "} does not evaluate to a numeric vector.")
   }

--- a/tests/testthat/test-mutate_variables.R
+++ b/tests/testthat/test-mutate_variables.R
@@ -62,3 +62,9 @@ test_that("mutate_variables works correctly for draws_rvars objects", {
   expect_equal(x$theta_2_sq, x$theta[[2]]^2, check.attributes = FALSE)
 })
 
+test_that("mutate_variables drops variables on assigning NULL", {
+  x <- example_draws()
+  x <- mutate_variables(x, mu = NULL, tau = NULL)
+  expect_equal(variables(x), paste0("theta[", 1:8, "]"))
+})
+

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -54,10 +54,11 @@ test_that("print.draws_list runs without errors", {
 test_that("print.draws_rvars runs without errors", {
   skip_on_os("windows")
   x <- as_draws_rvars(example_draws())
-  expect_output(
-    print(x),
-    "A draws_rvars: 100 iterations, 4 chains, and 3 variables",
-    fixed = TRUE
+  out <- capture.output(print(x))
+  expect_match(
+    out,
+    regexp = "A draws_rvars: 100 iterations, 4 chains, and 3 variables",
+    all = FALSE
   )
 
   x <- weight_draws(x, rep(1, ndraws(x)))

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -5,7 +5,10 @@ test_that("print.draws_matrix runs without errors", {
   )
 
   x <- weight_draws(x, rep(1, ndraws(x)))
-  expect_output(print(x), "hidden reserved variables \\{'\\.log_weight'\\}")
+  expect_output(
+    print(x),
+    "hidden reserved variables ..\\.log_weight.."
+  )
 })
 
 test_that("print.draws_array runs without errors", {
@@ -15,7 +18,10 @@ test_that("print.draws_array runs without errors", {
   )
 
   x <- weight_draws(x, rep(1, ndraws(x)))
-  expect_output(print(x), "hidden reserved variables \\{'\\.log_weight'\\}")
+  expect_output(
+    print(x),
+    "hidden reserved variables ..\\.log_weight.."
+  )
 })
 
 test_that("print.draws_df runs without errors", {
@@ -39,7 +45,10 @@ test_that("print.draws_list runs without errors", {
   )
 
   x <- weight_draws(x, rep(1, ndraws(x)))
-  expect_output(print(x), "hidden reserved variables \\{'\\.log_weight'\\}")
+  expect_output(
+    print(x),
+    "hidden reserved variables ..\\.log_weight.."
+  )
 })
 
 test_that("print.draws_rvars runs without errors", {
@@ -54,8 +63,7 @@ test_that("print.draws_rvars runs without errors", {
   x <- weight_draws(x, rep(1, ndraws(x)))
   expect_output(
     print(x),
-    "hidden reserved variables {'.log_weight'}",
-    fixed = TRUE
+    "hidden reserved variables ..\\.log_weight.."
   )
 })
 
@@ -65,8 +73,7 @@ test_that("print.draws_array handles reserved variables correctly", {
   expect_output(print(x, max_variables = 1), "variable = tau")
   expect_output(
     print(x),
-    "hidden reserved variables {'.log_weight'}",
-    fixed = TRUE
+    "hidden reserved variables ..\\.log_weight.."
   )
 })
 
@@ -76,8 +83,7 @@ test_that("print.draws_matrix handles reserved variables correctly", {
   expect_output(print(x, max_variables = 1), "tau")
   expect_output(
     print(x),
-    "hidden reserved variables {'.log_weight'}",
-    fixed = TRUE
+    "hidden reserved variables ..\\.log_weight.."
   )
 })
 
@@ -98,8 +104,7 @@ test_that("print.draws_list handles reserved variables correctly", {
   expect_output(print(x, max_variables = 1), "tau")
   expect_output(
     print(x),
-    "hidden reserved variables {'.log_weight'}",
-    fixed = TRUE
+    "hidden reserved variables ..\\.log_weight.."
   )
 })
 
@@ -110,8 +115,7 @@ test_that("print.draws_rvars handles reserved variables correctly", {
   expect_output(print(x, max_variables = 1), "tau")
   expect_output(
     print(x),
-    "hidden reserved variables {'.log_weight'}",
-    fixed = TRUE
+    "hidden reserved variables ..\\.log_weight.."
   )
 })
 

--- a/tests/testthat/test-rvar-print.R
+++ b/tests/testthat/test-rvar-print.R
@@ -1,51 +1,76 @@
 test_that("basic print.rvar works", {
-  skip_on_os("windows")
   x <- rvar(array(1:12, dim = c(2,2,3)))
   x_with_chains <- rvar(array(1:12, dim = c(2,2,3)), nchains = 2)
 
-  expect_output(print(rvar(), color = FALSE),
-"rvar<1>[0] mean ± sd:
-NULL",
-    fixed = TRUE
+  out <- capture.output(print(rvar(), color = FALSE))
+  expect_match(
+    out,
+    regexp = "rvar<1>\\[0\\] mean . sd:",
+    all = FALSE
+  )
+  expect_match(
+    out,
+    regexp = "NULL",
+    all = FALSE
   )
 
-  expect_output(print(x, color = FALSE),
-"rvar<2>[2,3] mean ± sd:\
-     [,1]         [,2]         [,3]        \
-[1,]  1.5 ± 0.71   5.5 ± 0.71   9.5 ± 0.71 \
-[2,]  3.5 ± 0.71   7.5 ± 0.71  11.5 ± 0.71 ",
-    fixed = TRUE
+  out <- capture.output(print(x, color = FALSE))
+  expect_match(
+    out,
+    regexp = "rvar<2>\\[2,3\\] mean . sd:",
+    all = FALSE
   )
-
-  expect_output(print(x_with_chains, color = FALSE),
-"rvar<1,2>[2,3] mean ± sd:\
-     [,1]         [,2]         [,3]        \
-[1,]  1.5 ± 0.71   5.5 ± 0.71   9.5 ± 0.71 \
-[2,]  3.5 ± 0.71   7.5 ± 0.71  11.5 ± 0.71 ",
-    fixed = TRUE
+  expect_match(
+    out,
+    regexp = "     \\[,1\\]         \\[,2\\]         \\[,3\\]        ",
+    all = FALSE
+  )
+  expect_match(
+    out,
+    regexp = "\\[1,\\]  1.5 . 0.71   5.5 . 0.71   9.5 . 0.71 ",
+    all = FALSE
+  )
+  out <- capture.output(print(x_with_chains, color = FALSE))
+  expect_match(
+    out,
+    regexp = "rvar<1,2>\\[2,3\\] mean . sd:",
+    all = FALSE
+  )
+  expect_match(
+    out,
+    regexp = "     \\[,1\\]         \\[,2\\]         \\[,3\\]        ",
+    all = FALSE
+  )
+  expect_match(
+    out,
+    regexp = "\\[1,\\]  1.5 . 0.71   5.5 . 0.71   9.5 . 0.71 ",
+    all = FALSE
+  )
+  expect_match(
+    out,
+    regexp = "\\[2,\\]  3.5 . 0.71   7.5 . 0.71  11.5 . 0.71",
+    all = FALSE
   )
 })
 
 test_that("basic str.rvar works", {
-  skip_on_os("windows")
   x <- rvar(array(1:24, dim = c(2,3,4)))
   x_with_chains <- rvar(array(1:24, dim = c(2,3,4)), nchains = 2)
 
   expect_output(str(rvar()),
-    " rvar<1>[0] ",
-    fixed = TRUE
+    " rvar<1>\\[0\\] "
   )
-  expect_output(str(rvar(1:3)),
-    " rvar<3>[1]  2 ± 1",
-    fixed = TRUE
+  out <- capture.output(str(rvar(1:3)))
+  expect_match(
+    out,
+    regexp = " rvar<3>\\[1\\]  2 . 1",
+    all = FALSE
   )
-  expect_output(str(x, vec.len = 5),
-    " rvar<2>[3,4]  1.5 ± 0.71  3.5 ± 0.71  5.5 ± 0.71  7.5 ± 0.71  9.5 ± 0.71 ...",
-    fixed = TRUE
-  )
-  expect_output(str(x_with_chains, vec.len = 5),
-    " rvar<1,2>[3,4]  1.5 ± 0.71  3.5 ± 0.71  5.5 ± 0.71  7.5 ± 0.71  9.5 ± 0.71 ...",
-    fixed = TRUE
+  out <- capture.output(str(x, vec.len = 5))
+  expect_match(
+    out,
+    regexp = " rvar<2>\\[3,4\\]  1.5 . 0.71  3.5 . 0.71  5.5 . 0.71  7.5 . 0.71  9.5 . 0.71 ...",
+    all = FALSE
   )
 
   x_with_attrs <- x
@@ -53,23 +78,26 @@ test_that("basic str.rvar works", {
   attr(draws_of(x_with_attrs), "foo") = list(1,2)
   attr(x_with_attrs, "bar") = list(1,2)
 
-  expect_output(str(x_with_attrs, vec.len = 5),
-    ' rvar<2>[3,4]  1.5 ± 0.71  3.5 ± 0.71  5.5 ± 0.71  7.5 ± 0.71  9.5 ± 0.71 ...
- - dimnames(*)=List of 2
-  ..$ : chr [1:3] "a" "b" "c"
-  ..$ : NULL
- - attr(draws_of(*), "foo")=List of 2
-  ..$ : num 1
-  ..$ : num 2
- - attr(*, "bar")=List of 2
-  ..$ : num 1
-  ..$ : num 2',
-    fixed = TRUE
+  out <- capture.output(str(x_with_attrs, vec.len = 5))
+  expect_match(
+    out,
+    regexp = " rvar<2>\\[3,4\\]  1.5 . 0.71  3.5 . 0.71  5.5 . 0.71  7.5 . 0.71  9.5 . 0.71 ...",
+    all = FALSE
   )
-
+  expect_match(
+    out,
+    regexp = " - dimnames\\(\\*\\)=List of 2",
+    all = FALSE
+  )
+  expect_match(
+    out,
+    regexp = '  \\.\\.\\$ : chr \\[1:3\\] "a" "b" "c"',
+    all = FALSE
+  )
 })
 
 test_that("glimpse on rvar works", {
+  skip_on_cran()
   x_vec <- rvar(array(1:24, dim = c(6,4)))
   x_matrix <- rvar(array(1:24, dim = c(2,3,4)))
 


### PR DESCRIPTION
#### Summary

I was wondering if the fixes in https://github.com/stan-dev/posterior/pull/228 were enough for CRAN and it seems that they helped: https://cran.r-project.org/web/checks/check_results_posterior.html

There is one more that popped up for `r-devel-linux-x86_64-debian-clang`. I don't know if CRAN sent any e-mails already or if they even do for devel errors, but still an easy fix and can get up to CRAN whenever you do the next release.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)