### PR TITLE
One more test fix for CRAN

### DIFF
--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -54,10 +54,11 @@ test_that("print.draws_list runs without errors", {
 test_that("print.draws_rvars runs without errors", {
   skip_on_os("windows")
   x <- as_draws_rvars(example_draws())
-  expect_output(
-    print(x),
-    "A draws_rvars: 100 iterations, 4 chains, and 3 variables",
-    fixed = TRUE
+  out <- capture.output(print(x))
+  expect_match(
+    out,
+    regexp = "A draws_rvars: 100 iterations, 4 chains, and 3 variables",
+    all = FALSE
   )
 
   x <- weight_draws(x, rep(1, ndraws(x)))


### PR DESCRIPTION
#### Summary

Trying again, I messed up the branches previously. Saying again:

I was wondering if the fixes in https://github.com/stan-dev/posterior/pull/228 were enough for CRAN and it seems that they helped: https://cran.r-project.org/web/checks/check_results_posterior.html

There is one more that popped up for r-devel-linux-x86_64-debian-clang. I don't know if CRAN sent any e-mails already or if they even do for devel errors, but still an easy fix and can get up to CRAN whenever you do the next release.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)