### PR TITLE
allow NULL rvars with ndraws() > 1, for #242

### DIFF
--- a/R/rvar-.R
+++ b/R/rvar-.R
@@ -107,7 +107,7 @@ rvar <- function(x = double(), dim = NULL, dimnames = NULL, nchains = 1L, with_c
 
 #' @importFrom vctrs new_vctr
 new_rvar <- function(x = double(), .nchains = 1L) {
-  if (length(x) == 0) {
+  if (is.null(x)) {
     x <- double()
   }
 
@@ -637,7 +637,9 @@ cleanup_draw_dims <- function(x) {
     # canonical NULL rvar is 1 draw of nothing
     # this ensures that (e.g.) extending a null rvar
     # with x[1] = something works.
-    dim(x) <- c(1, 0)
+    ndraws = NROW(x)
+    if (ndraws == 0) ndraws = 1
+    dim(x) <- c(ndraws, 0)
   }
   else if (length(dim(x)) <= 1) {
     # 1d vectors get treated as a single variable

--- a/R/rvar-.R
+++ b/R/rvar-.R
@@ -634,11 +634,10 @@ drop_chain_dim <- function(x) {
 #' @noRd
 cleanup_draw_dims <- function(x) {
   if (length(x) == 0) {
-    # canonical NULL rvar is 1 draw of nothing
+    # canonical NULL rvar is at least 1 draw of nothing
     # this ensures that (e.g.) extending a null rvar
     # with x[1] = something works.
-    ndraws = NROW(x)
-    if (ndraws == 0) ndraws = 1
+    ndraws <- max(NROW(x), 1)
     dim(x) <- c(ndraws, 0)
   }
   else if (length(dim(x)) <= 1) {

--- a/tests/testthat/test-rvar-slice.R
+++ b/tests/testthat/test-rvar-slice.R
@@ -126,7 +126,7 @@ test_that("indexing with [ works on a vector", {
   expect_equal(x[NA_integer_], rvar_from_array(x_array[NA_integer_,, drop = FALSE]))
   expect_equal(x[rep(NA_integer_,7)], rvar_from_array(x_array[rep(NA_integer_,7),, drop = FALSE]))
 
-  expect_equal(x[NULL], new_rvar())
+  expect_equal(x[NULL], new_rvar(array(numeric(), dim = c(5, 0))))
 
   expect_error(x[1,1])
 
@@ -182,7 +182,7 @@ test_that("indexing with [ works on an array", {
   expect_equal(x[NA_integer_,], rvar_from_array(x_array[NA_integer_,,, drop = FALSE]))
   expect_equal(x[rep(NA_integer_,7)], rvar_from_array(array(rep(NA_integer_,14), dim = c(7,2))))
 
-  expect_equal(x[NULL], new_rvar())
+  expect_equal(x[NULL], new_rvar(array(numeric(), dim = c(2, 0))))
 
   # logical index the length of the array works
   flat_index <- c(


### PR DESCRIPTION
#### Summary

This is a draft PR that allows NULLish rvars to have more than one draw. Previously these were normalized to 1 draw of nothing; this caused incorrect draws_rvars objects to be created:

```r
> draws_rvars(x = rvar(NULL), y = rvar(rnorm(100)))
# A draws_rvars: 1 iterations, 1 chains, and 2 variables
$x: rvar<1>[0] mean ± sd:
NULL

$y: rvar<100>[1] mean ± sd:
[1] 0.14 ± 0.92 
```

With this PR, that is fixed:

```r
> draws_rvars(x = rvar(NULL), y = rvar(rnorm(100)))
# A draws_rvars: 100 iterations, 1 chains, and 2 variables
$x: rvar<100>[0] mean ± sd:
NULL

$y: rvar<100>[1] mean ± sd:
[1] 0.0022 ± 1.1 
```

Currently leaving this as a draft as the question remains if it makes sense to allow rvars with 0 draws, which may take a bit more thought to implement to handle corner cases. See discussion at #242.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)