### PR TITLE
minor change in ESS estimation in mcse_sd based on more simulations

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -486,7 +486,7 @@ mcse_sd.default <- function(x, ...) {
   # has (X-E[X])^2. The following ESS is based on a relevant quantity
   # in the computation and is empirically a good choice.
   sims_c <- x - mean(x)
-  ess <- ess_mean(abs(sims_c))
+  ess <- ess_mean((sims_c)^2)
   # Variance of variance estimate by Kenney and Keeping (1951, p. 141),
   # which doesn't assume normality of sims.
   Evar <- mean(sims_c^2)


### PR DESCRIPTION
#### Summary

mcse_sd was estimating ESS from abs(x-E[x]). In my old simulations, this had worked better than (x-E[x])^2. It's likely that the change in how the rest of MCSE for sd is estimated (PR #233) did affect that now the more logical (x-E[x])^2 works better, as demonstrated by simulations run by @sethaxen.

Here are the plots for the new simulation results
![image](https://user-images.githubusercontent.com/6705400/210242930-840f9445-f1fb-4543-87f2-b92297bbbb66.png)
![image](https://user-images.githubusercontent.com/6705400/210242974-6f776e1a-02b4-4a7a-ae36-a359ae98f491.png)

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)