### PR TITLE
ensure as_draws_rvars preserves dims of length-1 arrays, closes #265

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@
 * Implemented faster `vec_proxy.rvar()` and `vec_restore.rvar()`, improving
   performance of `rvar`s in `tibble`s (and elsewhere `vctrs` is used).
 
+### Bug Fixes
+
+* Ensure that `as_draws_rvars()` preserves dimensions of length-1 arrays (#265).
+
 
 # posterior 1.3.1
 

--- a/R/as_draws_rvars.R
+++ b/R/as_draws_rvars.R
@@ -79,8 +79,9 @@ as_draws_rvars.draws_matrix <- function(x, ...) {
     var_i <- vars == var
     var_matrix <- x_at(var_i)
     attr(var_matrix, "nchains") <- NULL
+    var_indices <- vars_indices[var_i]
 
-    if (ncol(var_matrix) == 1) {
+    if (ncol(var_matrix) == 1 && nchar(var_indices[[1]][[3]]) == 0) {
       # single variable, no indices
       out <- rvar(var_matrix)
       dimnames(out) <- NULL
@@ -91,7 +92,7 @@ as_draws_rvars.draws_matrix <- function(x, ...) {
 
       # first, pull out the list of indices into a data frame
       # where each column is an index variable
-      indices <- vapply(vars_indices[var_i], `[[`, i = 3, character(1))
+      indices <- vapply(var_indices, `[[`, i = 3, character(1))
       indices <- as.data.frame(do.call(rbind, strsplit(indices, ",")),
                                stringsAsFactors = FALSE)
       unique_indices <- vector("list", length(indices))

--- a/tests/testthat/test-as_draws.R
+++ b/tests/testthat/test-as_draws.R
@@ -351,6 +351,14 @@ test_that("as_draws_rvars can accept lists of lists as input", {
   expect_equal(as_draws_rvars(example_draws()), as_draws_rvars(list_of_lists))
 })
 
+test_that("as_draws_rvars preserves dims of length-1 arrays", {
+  draws_array <- draws_array(`x[1,1,1]` = 1:5)
+  expect_equal(
+    draws_of(as_draws_rvars(draws_array)$x),
+    array(1:5, dim = c(5, 1, 1, 1), dimnames = list(1:5, NULL, NULL, NULL))
+  )
+})
+
 test_that("draws_df does not munge variable names", {
   draws_df <- draws_df(`x[1]` = 1:2, `x[2]` = 3:4)
   expect_equal(variables(draws_df), c("x[1]", "x[2]"))


### PR DESCRIPTION
#### Summary

This closes #265 by ensuring that the dimensions of length-1 arrays in are preserved when converted to draws_rvars format. 

@wds15 can you verify this solves the problems you had in OncoBayes2? Thanks!

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)