### PR TITLE
Remove `"list"` from rvar class definition.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 ### Bug Fixes
 
 * Ensure that `as_draws_rvars()` preserves dimensions of length-1 arrays (#265).
+* Fix some minor compatibility issues with `rvar`, `vctrs`, and `dplyr` (#267, #269).
 
 
 # posterior 1.3.1

--- a/R/rvar-.R
+++ b/R/rvar-.R
@@ -390,7 +390,7 @@ get_rvar_class <- function(x) {
 
 #' @export
 get_rvar_class.default <- function(x) {
-  c("rvar", "vctrs_vctr", "list")
+  c("rvar", "vctrs_vctr")
 }
 
 #' @export

--- a/tests/testthat/test-rvar-.R
+++ b/tests/testthat/test-rvar-.R
@@ -134,7 +134,7 @@ test_that("%in% works on rvars", {
   expect_equal(x %in% c(1, 3), res)
 })
 
-# tibbles -----------------------------------------------------------------
+# tibbles / dplyr --------------------------------------------------------------
 
 test_that("rvars work in tibbles", {
   skip_if_not_installed("dplyr")
@@ -173,6 +173,12 @@ test_that("rvars work in tibbles", {
     d = c(rvar(NA), NA, NA, df$x[[4]]),
   )
   expect_equal(tidyr::pivot_wider(df, names_from = g, values_from = x), ref2)
+
+  expect_equal(dplyr::first(df$x), x[1])
+
+  z = cbind(a = x, b = x + 1)
+  df$z = z
+  expect_equal(dplyr::mutate(dplyr::rowwise(df), w = z[,"b"])$w, z[,"b"])
 })
 
 # broadcasting ------------------------------------------------------------

--- a/tests/testthat/test-rvar-cast.R
+++ b/tests/testthat/test-rvar-cast.R
@@ -175,6 +175,10 @@ test_that("is.matrix/array on rvar works", {
   expect_true(is.array(x_arr))
 })
 
+test_that("vec_is_list(<rvar>) is FALSE", {
+  expect_equal(vctrs::vec_is_list(rvar()), FALSE)
+})
+
 
 # type conversion -----------------------------------------------------------
 


### PR DESCRIPTION
#### Summary

This PR closes #269 and #267 by removing `"list"` from the end of the class definition of `rvar`. This ensures that `vctrs::vec_is_list(<rvar>)` is `FALSE` (fixing some issues with dplyr, closing #269) and ensures that the S4 class definition of `"rvar"` does not redefine the S4 parent class of `"vctrs_vctr"` to be `"list"` (closing #267).

Since we already discussed this on #269, once the tests pass here I will merge.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)