### PR TITLE
One more minor fix for #269: define ggplot scale type for rvar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Suggests:
   dplyr,
   tidyr,
   knitr,
+  ggplot2,
   rmarkdown
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,8 @@
 ### Bug Fixes
 
 * Ensure that `as_draws_rvars()` preserves dimensions of length-1 arrays (#265).
-* Fix some minor compatibility issues with `rvar`, `vctrs`, and `dplyr` (#267, #269).
+* Fix some minor compatibility issues with `rvar`, `vctrs`, `dplyr`, and
+  `ggplot2` (#267, #269).
 
 
 # posterior 1.3.1

--- a/R/as_draws_df.R
+++ b/R/as_draws_df.R
@@ -224,8 +224,7 @@ is_draws_df_like <- function(x) {
 }
 
 # This generic is not exported here as {dplyr} is only in Suggests, so
-# we must export it in .onLoad() for compatibility with r < 3.6. See
-# help("s3_register", package = "vctrs") for more information.
+# we must export it in .onLoad() for compatibility with R < 3.6.
 dplyr_reconstruct.draws_df <- function(data, template) {
   data <- NextMethod("dplyr_reconstruct")
   data <- drop_draws_class_if_metadata_removed(data, warn = FALSE)

--- a/R/rvar-.R
+++ b/R/rvar-.R
@@ -382,6 +382,17 @@ match.rvar <- function(x, ...) {
 }
 
 
+# ggplot2::scale_type -----------------------------------------------------
+
+# This generic is not exported here as {ggplot2} is only in Suggests, so
+# we must export it in .onLoad() for compatibility with R < 3.6.
+scale_type.rvar <- function(x) {
+  # ensure that rvars used in ggplot2 aesthetics (as in e.g. ggdist) are passed
+  # through without modification and without raising a warning
+  "identity"
+}
+
+
 # helpers: classes --------------------------------------------------------
 
 get_rvar_class <- function(x) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,5 +6,7 @@
 
 .onLoad <- function(...) {
   # S3 generics for packages in Suggests, for compatibility with R < 3.6.
+  # See help("s3_register", package = "vctrs") for more information.
   vctrs::s3_register("dplyr::dplyr_reconstruct", "draws_df")
+  vctrs::s3_register("ggplot2::scale_type", "rvar")
 }

--- a/tests/testthat/test-rvar-.R
+++ b/tests/testthat/test-rvar-.R
@@ -181,6 +181,17 @@ test_that("rvars work in tibbles", {
   expect_equal(dplyr::mutate(dplyr::rowwise(df), w = z[,"b"])$w, z[,"b"])
 })
 
+
+# ggplot2 -----------------------------------------------------------------
+
+test_that("scale_type(<rvar>) works", {
+  skip_if_not_installed("ggplot2")
+
+  expect_no_condition(ggplot2::scale_type(rvar()))
+  expect_equal(ggplot2::scale_type(rvar()), "identity")
+})
+
+
 # broadcasting ------------------------------------------------------------
 
 test_that("broadcast_array works", {


### PR DESCRIPTION
#### Summary

This is another minor fix related to #269, caught due to @bwiernik's due diligence. It ensures that `rvar`s with the new class definition can still be used in ggplot2.

Apologies for not including it in the earlier PR, I missed a bug in my testing. Once tests pass I will merge this.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)