### PR TITLE
ensure rfun works with primitive functions and dots arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: posterior
 Title: Tools for Working with Posterior Distributions
-Version: 1.4.1
+Version: 1.4.1.9000
 Date: 2023-03-09
 Authors@R: c(person("Paul-Christian", "Bürkner", email = "paul.buerkner@gmail.com", role = c("aut", "cre")),
              person("Jonah", "Gabry", email = "jsg2201@columbia.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# posterior (development version)
+
+### Bug Fixes
+
+* Unsure `rfun()` works with primitive functions (#290).
+
+
 # posterior 1.4.1
 
 ### Bug Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-* Unsure `rfun()` works with primitive functions (#290).
+* Ensure `rfun()` works with primitive functions (#290) and dots arguments (#291).
 
 
 # posterior 1.4.1

--- a/R/rvar-rfun.R
+++ b/R/rvar-rfun.R
@@ -9,7 +9,10 @@
 #' @param rvar_args (character vector) The names of the arguments of `.f` that
 #'   should be allowed to accept [`rvar`]s as arguments. If `NULL` (the
 #'   default), all arguments to `.f` are turned into arguments that accept
-#'   [`rvar`]s.
+#'   [`rvar`]s, including arguments passed via `...` (if `rvar_dots` is `TRUE`).
+#' @param rvar_dots (logical) Should dots (`...`) arguments also be converted?
+#'   Only applies if `rvar_args` is `NULL` (i.e., all arguments are allowed to
+#'   be [`rvar`]s).
 #' @param ndraws (positive integer). The number of draws used to construct new
 #'   random variables if no [`rvar`]s are supplied as arguments to the
 #'   returned function. If `NULL`, `getOption("posterior.rvar_ndraws")` is used
@@ -49,40 +52,48 @@
 #'
 #' @family rfun
 #' @export
-rfun <- function (.f, rvar_args = NULL, ndraws = NULL) {
+rfun <- function (.f, rvar_args = NULL, rvar_dots = TRUE, ndraws = NULL) {
   # based loosely on base::Vectorize
+  rvar_dots <- as_one_logical(rvar_dots)
   ndraws <- ndraws %||% getOption("posterior.rvar_ndraws", 4000)
   .f <- rlang::as_function(.f)
 
-  f_formals <- formals(args(.f))
-  arg_names <- as.list(f_formals)
-  arg_names[["..."]] <- NULL
-  arg_names <- names(arg_names)
-  rvar_args <- as.character(rvar_args %||% arg_names)
+  # when rvar_args are not supplied and the user wants us to convert all `...`
+  # args as well, we convert everything. Otherwise, we will only convert what
+  # is specified in `rvar_args`
+  convert_all_args <- is.null(rvar_args) && rvar_dots
 
-  if (!all(rvar_args %in% arg_names)) {
+  f_formals <- formals(args(.f))
+  f_arg_names <- as.list(f_formals)
+  f_arg_names[["..."]] <- NULL
+  f_arg_names <- names(f_arg_names)
+  rvar_args <- as.character(rvar_args %||% f_arg_names)
+
+  if (!all(rvar_args %in% f_arg_names)) {
     stop_no_call("All arguments specified by `rvar_args` must be names of formal arguments of `.f`")
   }
 
-  FUNV <- function() {
+  rvar_f <- function() {
     args <- lapply(as.list(match.call())[-1L], eval, parent.frame())
     arg_names <-
       if (is.null(names(args))) character(length(args))
       else names(args)
 
     # convert arguments that are rvars into draws the function can be applied over
-    is_rvar_arg <- (arg_names %in% rvar_args) & as.logical(lapply(args, is_rvar))
-    rvar_args <- as_draws_rvars(args[is_rvar_arg])
-    .nchains <- max(1, nchains(rvar_args))
+    is_rvar_arg <-
+      (convert_all_args | arg_names %in% rvar_args) &
+      vapply(args, is_rvar, logical(1))
+    rvar_args_draws <- as_draws_rvars(args[is_rvar_arg])
+    .nchains <- max(1, nchains(rvar_args_draws))
 
-    if (length(rvar_args) == 0) {
+    if (length(rvar_args_draws) == 0) {
       # no rvar arguments, so just create a random variable by applying this function
       # ndraws times
       list_of_draws <- replicate(ndraws, do.call(.f, args), simplify = FALSE)
     } else {
-      list_of_draws <- lapply(seq_len(ndraws(rvar_args)), function(i) {
-        variables <- get_variables_from_one_draw(rvar_args, i)
-        do.call(.f, c(variables, args[!is_rvar_arg]))
+      list_of_draws <- lapply(seq_len(ndraws(rvar_args_draws)), function(i) {
+        args[is_rvar_arg] <- get_variables_from_one_draw(rvar_args_draws, i)
+        do.call(.f, args)
       })
     }
     # Need to add a first dimension before unchopping (this will be the draws dimension)
@@ -94,8 +105,8 @@ rfun <- function (.f, rvar_args = NULL, ndraws = NULL) {
     })
     new_rvar(vctrs::list_unchop(list_of_draws), .nchains = .nchains)
   }
-  formals(FUNV) <- f_formals
-  FUNV
+  formals(rvar_f) <- f_formals
+  rvar_f
 }
 
 #' Execute expressions of random variables

--- a/R/rvar-rfun.R
+++ b/R/rvar-rfun.R
@@ -54,7 +54,8 @@ rfun <- function (.f, rvar_args = NULL, ndraws = NULL) {
   ndraws <- ndraws %||% getOption("posterior.rvar_ndraws", 4000)
   .f <- rlang::as_function(.f)
 
-  arg_names <- as.list(formals(.f))
+  f_formals <- formals(args(.f))
+  arg_names <- as.list(f_formals)
   arg_names[["..."]] <- NULL
   arg_names <- names(arg_names)
   rvar_args <- as.character(rvar_args %||% arg_names)
@@ -93,7 +94,7 @@ rfun <- function (.f, rvar_args = NULL, ndraws = NULL) {
     })
     new_rvar(vctrs::list_unchop(list_of_draws), .nchains = .nchains)
   }
-  formals(FUNV) <- formals(.f)
+  formals(FUNV) <- f_formals
   FUNV
 }
 

--- a/man/rfun.Rd
+++ b/man/rfun.Rd
@@ -4,7 +4,7 @@
 \alias{rfun}
 \title{Create functions of random variables}
 \usage{
-rfun(.f, rvar_args = NULL, ndraws = NULL)
+rfun(.f, rvar_args = NULL, rvar_dots = TRUE, ndraws = NULL)
 }
 \arguments{
 \item{.f}{(multiple options) A function to turn into a function that accepts
@@ -17,7 +17,11 @@ and/or produces random variables:
 \item{rvar_args}{(character vector) The names of the arguments of \code{.f} that
 should be allowed to accept \code{\link{rvar}}s as arguments. If \code{NULL} (the
 default), all arguments to \code{.f} are turned into arguments that accept
-\code{\link{rvar}}s.}
+\code{\link{rvar}}s, including arguments passed via \code{...} (if \code{rvar_dots} is \code{TRUE}).}
+
+\item{rvar_dots}{(logical) Should dots (\code{...}) arguments also be converted?
+Only applies if \code{rvar_args} is \code{NULL} (i.e., all arguments are allowed to
+be \code{\link{rvar}}s).}
 
 \item{ndraws}{(positive integer). The number of draws used to construct new
 random variables if no \code{\link{rvar}}s are supplied as arguments to the

--- a/tests/testthat/test-rvar-rfun.R
+++ b/tests/testthat/test-rvar-rfun.R
@@ -47,6 +47,25 @@ test_that("rfun works on primitive functions", {
   expect_equal(rfun_sin(x), sin(x))
 })
 
+test_that("rfun works on dots arguments", {
+  g <- function(x, y, z = 2) {
+    c(x, y, z)
+  }
+  f <- function(x, ...) {
+    g(x, ...)
+  }
+
+  expect_equal(rfun(f)(z = rvar(1:3), x = rvar(3:5), 3), c(rvar(3:5), 3, rvar(1:3)))
+})
+
+test_that("rfun works on formula functions", {
+  expect_equal(rfun(~ . ^ 2)(rvar(1:3)), rvar((1:3)^2))
+  expect_equal(rfun(~ .x ^ 2)(rvar(1:3)), rvar((1:3)^2))
+  expect_equal(rfun(~ ..1 ^ 2)(rvar(1:3)), rvar((1:3)^2))
+  expect_equal(rfun(~ .x ^ .y)(rvar(1:3), 2), rvar((1:3)^2))
+  expect_equal(rfun(~ ..1 ^ ..2)(rvar(1:3), 2), rvar((1:3)^2))
+})
+
 test_that("rdo allows setting the dimensions of the result", {
   expect_equal(rdo(1:10, dim = c(2,5), ndraws = 1), rvar(array(1:10, dim = c(1,2,5))))
 })

--- a/tests/testthat/test-rvar-rfun.R
+++ b/tests/testthat/test-rvar-rfun.R
@@ -39,6 +39,14 @@ test_that("rfun works on functions without rvar arguments", {
   expect_equal(rfun(f, rvar_args = NULL, ndraws = 10)(NULL), rvar(1:10))
 })
 
+test_that("rfun works on primitive functions", {
+  x = rvar(1:10)
+
+  rfun_sin = rfun(sin)
+  expect_equal(names(formals(rfun_sin)), "x")
+  expect_equal(rfun_sin(x), sin(x))
+})
+
 test_that("rdo allows setting the dimensions of the result", {
   expect_equal(rdo(1:10, dim = c(2,5), ndraws = 1), rvar(array(1:10, dim = c(1,2,5))))
 })


### PR DESCRIPTION
#### Summary

This ensures rfun works with primitive functions (closes #290) and dots arguments (closes #291).

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)