### PR TITLE
Minor bugfix for use of summarise_draws in Rmarkdown

### DIFF
--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -286,7 +286,7 @@ print.draws_summary <- function(x, ..., num_args = NULL) {
   num_args <- num_args %||% attr(x, "num_args")
   for (i in seq_cols(x)) {
     if (is.numeric(x[[i]])) {
-      x[[i]] <- do.call(tibble::num, c(list(x[[i]]), num_args))
+      x[[i]] <- do.call(tibble::set_num_opts, c(list(x[[i]]), num_args))
     }
   }
   NextMethod()

--- a/tests/testthat/test-summarise_draws.R
+++ b/tests/testthat/test-summarise_draws.R
@@ -120,11 +120,11 @@ test_that(paste(
   expect_identical(sum_x, parsum_x)
 })
 
-test_that("summarise_draws supports tibble::num correctly", {
+test_that("summarise_draws supports tibble::set_num_opts correctly", {
   x <- example_draws()
   expect_output(
     print(summarise_draws(x, .num_args = list(sigfig = 2, notation="dec"))),
-    "<dec:2>"
+    "mu\\s+4.2\\s+"
   )
 })
 


### PR DESCRIPTION
This is a minor fix that perhaps I should have noticed and fixed with #275. When using `summarise_draws()` in Rmarkdown in RStudio, negative numbers get printed oddly, because the value of `print(summarise_draws())` (not just `summarise_draws()`) seems to be used under the hood to construct the table, and `print.draws_summary()` modifies column types. Note column `q5`:

![image](https://github.com/stan-dev/posterior/assets/6345019/002279ac-bbf2-4c5d-baf5-ef3699c1ba38)

The solution is to use `tibble:set_num_opts` instead of `tibble:num` in the printing code, as this adds an attribute with the formatting information to the column rather than changing it to a `pillar_num` object. Note that the column types above are also `pillar_num`, when they should be `dbl`.

This PR implements that simple fix. Output under this PR:

![image](https://github.com/stan-dev/posterior/assets/6345019/63d591f4-1013-4bae-bbcc-5460f2501506)

I don't think this really deserves a news entry since it's pretty minor and similar to the recently-fixed #275 anyway, but can write one if you like.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)