### PR TITLE
CRAN test fixes for rvar on R 4.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,8 @@
 * Ensure `rfun()` works with primitive functions (#290) and dots arguments (#291).
 * Provide implementations of `vctrs::vec_proxy_equal()`, `vctrs::vec_proxy_compare()`,
   and `vctrs::vec_proxy_order()`.
-* Future-proof `cbind(<rvar>)` and `rbind(<rvar>)` for R 4.4 (#304).
+* Minor future-proofing of `cbind(<rvar>)`, `rbind(<rvar>)`, and `chol(<rvar>)`
+  for R 4.4 (#304).
 
 
 # posterior 1.4.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Ensure `rfun()` works with primitive functions (#290) and dots arguments (#291).
 * Provide implementations of `vctrs::vec_proxy_equal()`, `vctrs::vec_proxy_compare()`,
   and `vctrs::vec_proxy_order()`.
+* Future-proof `cbind(<rvar>)` and `rbind(<rvar>)` for R 4.4 (#304).
 
 
 # posterior 1.4.1

--- a/R/rvar-bind.R
+++ b/R/rvar-bind.R
@@ -26,16 +26,18 @@ c.rvar <- function(...) {
 }
 
 #' @export
-rbind.rvar <- function(...) {
-  # not sure why deparse.level is not passed here correctly...
-  deparse.level <- rlang::caller_env()$deparse.level %||% 1
+rbind.rvar <- function(..., deparse.level = 1) {
+  # deparse.level is not correctly passed here by the default rbind
+  # implementation in R < 4.4, so we grab it from the calling environment
+  deparse.level <- rlang::caller_env()$deparse.level %||% deparse.level
   bind_rvars(list(...), as.list(substitute(list(...))[-1]), deparse.level)
 }
 
 #' @export
-cbind.rvar <- function(...) {
-  # not sure why deparse.level is not passed here correctly...
-  deparse.level <- rlang::caller_env()$deparse.level %||% 1
+cbind.rvar <- function(..., deparse.level = 1) {
+  # deparse.level is not correctly passed here by the default cbind
+  # implementation in R < 4.4, so we grab it from the calling environment
+  deparse.level <- rlang::caller_env()$deparse.level %||% deparse.level
   bind_rvars(list(...), as.list(substitute(list(...))[-1]), deparse.level, axis = 2)
 }
 

--- a/R/rvar-math.R
+++ b/R/rvar-math.R
@@ -237,6 +237,7 @@ chol.rvar <- function(x, ...) {
 
   # drop dimension names (chol.tensor screws them around)
   names(dim(result)) <- NULL
+  dimnames(result) <- NULL
 
   new_rvar(result, .nchains = nchains(x))
 }

--- a/R/rvar-slice.R
+++ b/R/rvar-slice.R
@@ -278,14 +278,14 @@ NULL
     index[seq(length(index) + 1, length(dim(.draws)) - 1)] = list(missing_arg())
   }
 
-  x <- inject(
-    new_rvar(.draws[!!!draws_index, !!!index, drop = FALSE], .nchains = nchains(x))
-  )
+  .draws <- inject(.draws[!!!draws_index, !!!index, drop = FALSE])
 
   if (!is_missing(draws_index[[1]])) {
     # if we subsetted draws, replace draw ids with sequential ids
-    rownames(draws_of(x)) <- seq_len(ndraws(x))
+    rownames(.draws) <- seq_len(NROW(.draws))
   }
+
+  x <- new_rvar(.draws, .nchains = nchains(x))
 
   if (drop) {
     x <- drop(x)

--- a/tests/testthat/test-rvar-slice.R
+++ b/tests/testthat/test-rvar-slice.R
@@ -165,7 +165,7 @@ test_that("indexing with [ works on a vector", {
   expect_equal(x[NA_integer_], rvar_from_array(x_array[NA_integer_,, drop = FALSE]))
   expect_equal(x[rep(NA_integer_,7)], rvar_from_array(x_array[rep(NA_integer_,7),, drop = FALSE]))
 
-  expect_equal(x[NULL], new_rvar(array(numeric(), dim = c(5, 0))))
+  expect_equal(x[NULL], rvar_from_array(x_array[NULL, , drop = FALSE]))
 
   expect_error(x[1,1])
 


### PR DESCRIPTION
#### Summary

This is a handful of minor fixes for rvar on R 4.4, and closes #304. All of these fixes address slight changes in the handling of dimnames or function arguments in R 4.4 and have no meaningful impact on functionality.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)