### PR TITLE
Regenerate draw ids for bind_draws(<draws_rvar>, along = "chain")

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
   and `vctrs::vec_proxy_order()`.
 * Minor future-proofing of `cbind(<rvar>)`, `rbind(<rvar>)`, and `chol(<rvar>)`
   for R 4.4 (#304).
+* Ensure that `bind_draws(<draws_rvars>)` regenerates draw ids when binding along
+  chains or draws; this also fixes a bug in `split_chains(<draws_rvars>)` (#300).
 
 
 # posterior 1.4.1

--- a/R/bind_draws.R
+++ b/R/bind_draws.R
@@ -202,7 +202,6 @@ bind_draws.draws_rvars <- function(x, ..., along = "variable") {
   } else if (along == "iteration") {
     stop_no_call("Cannot bind 'draws_rvars' objects along 'iteration'.")
   } else if (along %in% c("chain", "draw")) {
-    # TODO here: make sure both "draw" and "chain" result in new draw_ids (add tests)
     check_same_fun_output(dots, variables)
     if (along == "chain") {
       check_same_fun_output(dots, iteration_ids)
@@ -216,7 +215,11 @@ bind_draws.draws_rvars <- function(x, ..., along = "variable") {
     out <- lapply(seq_along(dots[[1]]), function(var_i) {
       vars <- lapply(dots, `[[`, var_i)
       var_draws <- lapply(vars, draws_of)
-      out <- rvar(abind(var_draws, along = 1), nchains = nchains)
+      new_draws <- abind(var_draws, along = 1)
+      # must regenerate draw ids in case binding along draws or chains generates
+      # duplicate or out of sequence draw ids
+      rownames(new_draws) <- seq_rows(new_draws)
+      out <- rvar(new_draws, nchains = nchains)
       out
     })
     names(out) <- names(dots[[1]])

--- a/R/bind_draws.R
+++ b/R/bind_draws.R
@@ -202,6 +202,7 @@ bind_draws.draws_rvars <- function(x, ..., along = "variable") {
   } else if (along == "iteration") {
     stop_no_call("Cannot bind 'draws_rvars' objects along 'iteration'.")
   } else if (along %in% c("chain", "draw")) {
+    # TODO here: make sure both "draw" and "chain" result in new draw_ids (add tests)
     check_same_fun_output(dots, variables)
     if (along == "chain") {
       check_same_fun_output(dots, iteration_ids)

--- a/R/order_draws.R
+++ b/R/order_draws.R
@@ -78,6 +78,7 @@ order_draws.rvar <- function(x, ...) {
     # if ordering is needed, must also merge chains (as out-of-order draws
     # imply chain information is no longer meaningful)
     if (nchains(x) > 1) {
+      warn_merge_chains("index")
       x <- merge_chains(x)
     }
     draws_of(x) <- vec_slice(draws_of(x), draw_order)

--- a/tests/testthat/test-bind_draws.R
+++ b/tests/testthat/test-bind_draws.R
@@ -23,6 +23,7 @@ test_that("bind_draws works for draws_matrix objects", {
     nchains(draws1) + nchains(draws2)
   )
   expect_equal(variables(draws_new), variables(draws1))
+  expect_equal(draw_ids(draws_new), seq_len(ndraws(draws_new)))
 
   draws_new <- bind_draws(draws1, draws3, along = "draw")
   expect_equal(
@@ -51,6 +52,7 @@ test_that("bind_draws works for draws_array objects", {
   draws_new <- bind_draws(draws1, draws2, along = "chain")
   expect_equal(nchains(draws_new), nchains(draws1) + nchains(draws2))
   expect_equal(variables(draws_new), variables(draws1))
+  expect_equal(draw_ids(draws_new), seq_len(ndraws(draws_new)))
 
   draws_new <- bind_draws(draws1, draws3, along = "iteration")
   expect_equal(
@@ -82,6 +84,7 @@ test_that("bind_draws works for draws_df objects", {
   draws_new <- bind_draws(draws1, draws2, along = "chain")
   expect_equal(nchains(draws_new), nchains(draws1) + nchains(draws2))
   expect_equal(variables(draws_new), variables(draws1))
+  expect_equal(draw_ids(draws_new), seq_len(ndraws(draws_new)))
 
   draws_new <- bind_draws(draws1, draws3, along = "iteration")
   expect_equal(
@@ -150,6 +153,7 @@ test_that("bind_draws works for draws_list objects", {
   draws_new <- bind_draws(draws1, draws2, along = "chain")
   expect_equal(nchains(draws_new), nchains(draws1) + nchains(draws2))
   expect_equal(variables(draws_new), variables(draws1))
+  expect_equal(draw_ids(draws_new), seq_len(ndraws(draws_new)))
 
   draws_new <- bind_draws(draws1, draws3, along = "iteration")
   expect_equal(
@@ -181,6 +185,7 @@ test_that("bind_draws works for draws_rvars objects", {
   draws_new <- bind_draws(draws1, draws2, along = "chain")
   expect_equal(nchains(draws_new), nchains(draws1) + nchains(draws2))
   expect_equal(variables(draws_new), variables(draws1))
+  expect_equal(draw_ids(draws_new), seq_len(ndraws(draws_new)))
 
   expect_error(bind_draws(draws1, draws3, along = "iteration"),
     "Cannot bind 'draws_rvars' objects along 'iteration'")

--- a/tests/testthat/test-split_chains.R
+++ b/tests/testthat/test-split_chains.R
@@ -1,0 +1,11 @@
+test_that("split_chains(<draws_rvar>) works correctly", {
+  x_array <- array(1:48, dim = c(4, 3, 4))
+  x_rvar <- rvar(x_array, with_chains = TRUE)
+  x_draws <- draws_rvars(x = x_rvar)
+
+  x_split_array <- abind::abind(x_array[1:2,,], x_array[3:4,,], along = 2)
+  x_split_rvar <- rvar(x_split_array, with_chains = TRUE)
+  x_split_draws <- draws_rvars(x = x_split_rvar)
+
+  expect_equal(split_chains(x_draws), x_split_draws)
+})


### PR DESCRIPTION
#### Summary

This PR closes #300. The underlying issue in #300 is that `bind_draws(<draws_rvars>, along = "chain")` did not re-generate draw ids, so the resulting object from `split_chain(<draws_rvars>)` (which uses `bind_draws()` could have multiple draws with th same id.

Notably, this  bug might have been caught more easily if there was a warning issued by `order_draws(<rvar>)` if it needs to merge chains. I added a simple warning using `warn_merge_chains()`, but with the default settings that warning is not issued anyway. So I'm not sure if we want some other long-term solution, maybe warning levels or something?

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)