### PR TITLE
fix pareto smoothing weights test

### DIFF
--- a/tests/testthat/test-pareto_smooth.R
+++ b/tests/testthat/test-pareto_smooth.R
@@ -198,7 +198,7 @@ test_that("pareto_smooth works for log_weights", {
   ps <- pareto_smooth(lw, are_log_weights = TRUE, verbose = FALSE, ndraws_tail = 10, return_k = TRUE)
 
   # only right tail is smoothed
-  expect_equal(ps$x[1:15], lw[1:15])
+  expect_equal(ps$x[1:15] + max(lw), lw[1:15])
 
   expect_true(ps$diagnostics$khat > 0.7)
 


### PR DESCRIPTION
#### Summary

Minor fix to test for log weight pareto smoothing

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)