### PR TITLE
Pareto k tail fix

### DIFF
--- a/R/pareto_smooth.R
+++ b/R/pareto_smooth.R
@@ -320,7 +320,7 @@ pareto_smooth.default <- function(x,
 
     # right tail
     smoothed <-.pareto_smooth_tail(
-      x = x,
+      x = smoothed$x,
       ndraws_tail = ndraws_tail,
       tail = "right",
       are_log_weights = are_log_weights,

--- a/tests/testthat/test-pareto_smooth.R
+++ b/tests/testthat/test-pareto_smooth.R
@@ -6,6 +6,22 @@ test_that("pareto_khat returns expected reasonable values", {
 
 })
 
+
+test_that("pareto_khat handles constant tail correctly", {
+
+  # left tail is constant, so khat should be NA, but for "both" it
+  # should be the same as the right tail
+  x <- c(rep(-100, 10), sort(rnorm(100)))
+
+  expect_true(is.na(pareto_khat(x, tail = "left", ndraws_tail = 10)))
+  expect_equal(
+    pareto_khat(x, tail = "right", ndraws_tail = 10),
+    pareto_khat(x, tail = "both", ndraws_tail = 10)
+  )
+
+})
+
+
 test_that("pareto_khat handles tail argument", {
 
   # as tau is bounded (0, Inf) the left pareto k should be lower than

--- a/tests/testthat/test-pareto_smooth.R
+++ b/tests/testthat/test-pareto_smooth.R
@@ -196,14 +196,27 @@ test_that("pareto_khat functions work with rvars with and without chains", {
 
 })
 
-test_that("pareto_smooth returns x with smoothed tail", {
-  tau <- extract_variable_matrix(example_draws(), "tau")
+test_that("pareto_smooth returns x with smoothed tail(s)", {
+  mu <- extract_variable_matrix(example_draws(), "mu")
 
-  tau_smoothed <- pareto_smooth(tau, ndraws_tail = 10, tail = "right", return_k = TRUE)$x
+  mu_smoothed_right <- pareto_smooth(mu, ndraws_tail = 10, tail = "right", return_k = TRUE)$x
 
-  expect_equal(sort(tau)[1:390], sort(tau_smoothed)[1:390])
+  mu_smoothed_left <- pareto_smooth(mu, ndraws_tail = 10, tail = "left", return_k = TRUE)$x
 
-  expect_false(isTRUE(all.equal(sort(tau), sort(tau_smoothed))))
+  mu_smoothed_both <- pareto_smooth(mu, ndraws_tail = 10, tail = "both", return_k = TRUE)$x
+
+  expect_equal(sort(mu)[1:390], sort(mu_smoothed_right)[1:390])
+  expect_equal(sort(mu_smoothed_both)[11:400], sort(mu_smoothed_right)[11:400])
+
+  expect_equal(sort(mu)[11:400], sort(mu_smoothed_left)[11:400])
+  expect_equal(sort(mu_smoothed_both)[1:390], sort(mu_smoothed_left)[1:390])
+
+  expect_false(isTRUE(all.equal(sort(mu), sort(mu_smoothed_left))))
+  expect_false(isTRUE(all.equal(sort(mu), sort(mu_smoothed_right))))
+  expect_false(isTRUE(all.equal(sort(mu), sort(mu_smoothed_both))))
+
+  expect_false(isTRUE(all.equal(sort(mu_smoothed_both), sort(mu_smoothed_left))))
+  expect_false(isTRUE(all.equal(sort(mu_smoothed_both), sort(mu_smoothed_right))))
 
 })
 


### PR DESCRIPTION
#### Summary

As brought up by @avehtari in issue #345, when one tail is constant, but `tail = "both"` is specified, it is better to return the diagnostic for the non-constant tail rather than `NA`.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)