### PR TITLE
modify summarise_draws internals not to coerce values to same type

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -14,6 +14,31 @@ named_list <- function(names, values = NULL) {
   setNames(values, names)
 }
 
+
+# flatten a list that may contain vectors into a single level list
+unnest <- function(x) {
+
+  out <- list()
+
+  for (i in seq_along(x)) {
+    name_i <- names(x[i])
+    if (length(x[[i]]) > 1) {
+      if (rlang::is_named(x[[i]])) {
+        name_j <- names(x[[i]])
+      } else {
+        name_j <- paste0(name_i, ".", c(1:length(x[[i]])))
+      }
+      for (j in seq_along(x[[i]])) {
+        out[[name_j[j]]] <- x[[i]][[j]]
+      }
+    } else {
+      out[[name_i]] <- x[[i]]
+    }
+  }
+  out
+}
+
+
 # unlist lapply output
 ulapply <- function(X, FUN, ..., recursive = TRUE, use.names = TRUE) {
   unlist(lapply(X, FUN, ...), recursive, use.names)

--- a/R/summarise_draws.R
+++ b/R/summarise_draws.R
@@ -341,30 +341,21 @@ summarise_draws_helper <- function(x, funs, .args) {
   variables_x <- variables(x)
   # get length and output names, calculated on the first variable
   out_1 <- create_summary_list(x, variables_x[1], funs, .args)
-  the_names <- vector(mode = "list", length = length(funs))
-  for (i in seq_along(out_1)){
-    if (rlang::is_named(out_1[[i]])) {
-      the_names[[i]] <- names(out_1[[i]])
-    } else if (length(out_1[[i]]) > 1) {
-      the_names[[i]] <- paste0(names(out_1)[i], ".", c(1:length(out_1[[i]])))
-    } else {
-      the_names[[i]] <- names(out_1)[i]
-    }
-  }
-  the_names <- unlist(the_names)
+  out_1 <- unnest(out_1)
+  the_names <- names(out_1)
   # Check for naming issues prior do doing lengthy computation
   if ("variable" %in% the_names) {
     stop_no_call("Name 'variable' is reserved in 'summarise_draws'.")
   }
   # Pre-allocate matrix to store output
-  out <- matrix(NA, nrow = length(variables_x), ncol = length(the_names))
+  out <- data.frame(matrix(NA, nrow = length(variables_x), ncol = length(the_names)))
   colnames(out) <- the_names
-  out[1, ] <- unlist(out_1)
+  out[1, ] <- out_1
   # Do the computation for all remaining variables
   if (length(variables_x) > 1L) {
     for (v_ind in 2:length(variables_x)) {
       out_v <- create_summary_list(x, variables_x[v_ind], funs, .args)
-      out[v_ind, ] <- unlist(out_v)
+      out[v_ind, ] <- unnest(out_v)
     }
   }
   out <- tibble::as_tibble(out)


### PR DESCRIPTION
#### Summary

This would fix #355.

As it is affecting `summarise_draws`, which is one of the main functions in `posterior`, I think this change needs to be considered carefully. It might be less efficient than currently implemented, so I am opening this PR now to check how the benchmarks for `summarise_draws` perform.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)