### PR TITLE
type check assertions for rvar draws, closes #363

### DIFF
--- a/R/rvar-.R
+++ b/R/rvar-.R
@@ -800,6 +800,13 @@ drop_chain_dim <- function(x) {
 #' (first one is draws), etc.
 #' @noRd
 cleanup_rvar_draws <- function(x) {
+  assert(
+    check_numeric(x),
+    check_logical(x),
+    check_factor(x),
+    check_character(x)
+  )
+
   if (length(x) == 0) {
     # canonical NULL rvar is at least 1 draw of nothing
     # this ensures that (e.g.) extending a null rvar


### PR DESCRIPTION
#### Summary

Adds assertions to prevent draws of invalid types being used in an rvar. Closes #363.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)