### PR TITLE
`r_eff` default to `NULL`

### DIFF
--- a/R/pareto_smooth.R
+++ b/R/pareto_smooth.R
@@ -250,7 +250,7 @@ pareto_smooth.rvar <- function(x, return_k = FALSE, extra_diags = FALSE, ...) {
 #' @export
 pareto_smooth.default <- function(x,
                                   tail = c("both", "right", "left"),
-                                  r_eff = 1,
+                                  r_eff = NULL,
                                   ndraws_tail = NULL,
                                   return_k = FALSE,
                                   extra_diags = FALSE,

--- a/man-roxygen/args-pareto.R
+++ b/man-roxygen/args-pareto.R
@@ -15,7 +15,7 @@
 #'   al. (2024)).
 #' @param r_eff (numeric) relative effective sample size estimate. If
 #'   `r_eff` is NULL, it will be calculated assuming the draws are
-#'   from MCMC. Default is 1.
+#'   from MCMC. Default is NULL.
 #' @param verbose (logical) Should diagnostic messages be printed? If
 #'   `TRUE`, messages related to Pareto diagnostics will be
 #'   printed. Default is `FALSE`.

--- a/man/pareto_diags.Rd
+++ b/man/pareto_diags.Rd
@@ -68,7 +68,7 @@ The default is \code{"both"}.}
 
 \item{r_eff}{(numeric) relative effective sample size estimate. If
 \code{r_eff} is NULL, it will be calculated assuming the draws are
-from MCMC. Default is 1.}
+from MCMC. Default is NULL.}
 
 \item{ndraws_tail}{(numeric) number of draws for the tail. If
 \code{ndraws_tail} is not specified, it will be calculated as
@@ -134,8 +134,8 @@ pareto_diags(d$Sigma)
 \references{
 Aki Vehtari, Daniel Simpson, Andrew Gelman, Yuling Yao and
 Jonah Gabry (2024). Pareto Smoothed Importance Sampling.
-\emph{Journal of Machine Learning Research}, accepted for publication.
-arxiv:arXiv:1507.02646 (version 8)
+\emph{Journal of Machine Learning Research}, 25(72):1-58.
+\href{https://jmlr.org/papers/v25/19-556.html}{PDF}
 }
 \seealso{
 \code{\link{pareto_khat}} for only calculating khat, and

--- a/man/pareto_khat.Rd
+++ b/man/pareto_khat.Rd
@@ -41,7 +41,7 @@ The default is \code{"both"}.}
 
 \item{r_eff}{(numeric) relative effective sample size estimate. If
 \code{r_eff} is NULL, it will be calculated assuming the draws are
-from MCMC. Default is 1.}
+from MCMC. Default is NULL.}
 
 \item{ndraws_tail}{(numeric) number of draws for the tail. If
 \code{ndraws_tail} is not specified, it will be calculated as
@@ -76,8 +76,8 @@ pareto_khat(d$Sigma)
 \references{
 Aki Vehtari, Daniel Simpson, Andrew Gelman, Yuling Yao and
 Jonah Gabry (2024). Pareto Smoothed Importance Sampling.
-\emph{Journal of Machine Learning Research}, accepted for publication.
-arxiv:arXiv:1507.02646 (version 8)
+\emph{Journal of Machine Learning Research}, 25(72):1-58.
+\href{https://jmlr.org/papers/v25/19-556.html}{PDF}
 }
 \seealso{
 \code{\link{pareto_diags}} for additional related diagnostics, and

--- a/man/pareto_smooth.Rd
+++ b/man/pareto_smooth.Rd
@@ -13,7 +13,7 @@ pareto_smooth(x, ...)
 \method{pareto_smooth}{default}(
   x,
   tail = c("both", "right", "left"),
-  r_eff = 1,
+  r_eff = NULL,
   ndraws_tail = NULL,
   return_k = FALSE,
   extra_diags = FALSE,
@@ -53,7 +53,7 @@ The default is \code{"both"}.}
 
 \item{r_eff}{(numeric) relative effective sample size estimate. If
 \code{r_eff} is NULL, it will be calculated assuming the draws are
-from MCMC. Default is 1.}
+from MCMC. Default is NULL.}
 
 \item{ndraws_tail}{(numeric) number of draws for the tail. If
 \code{ndraws_tail} is not specified, it will be calculated as
@@ -94,8 +94,8 @@ pareto_smooth(d$Sigma)
 \references{
 Aki Vehtari, Daniel Simpson, Andrew Gelman, Yuling Yao and
 Jonah Gabry (2024). Pareto Smoothed Importance Sampling.
-\emph{Journal of Machine Learning Research}, accepted for publication.
-arxiv:arXiv:1507.02646 (version 8)
+\emph{Journal of Machine Learning Research}, 25(72):1-58.
+\href{https://jmlr.org/papers/v25/19-556.html}{PDF}
 }
 \seealso{
 \code{\link{pareto_khat}} for only calculating khat, and


### PR DESCRIPTION
#### Summary

Sets `r_eff` back to `NULL` as default for `pareto_smooth`. At a later time, this may be changed, but now this fixes the inconsistency.

Fixes #368 

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)