### PR TITLE
fix autocorrelation() not printing

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -608,6 +608,7 @@ autocovariance <- function(x) {
 autocorrelation <- function(x) {
   ac <- autocovariance(x)
   ac <- ac / ac[1]
+  ac
 }
 
 #' Rank normalization

--- a/R/misc.R
+++ b/R/misc.R
@@ -238,3 +238,4 @@ has_s3_method <- function(f, signature) {
   }
   FALSE
 }
+


### PR DESCRIPTION
#### Summary

closes #375

Fixes autocorrelation() function not printing its return value.  

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)