### PR TITLE
fix rdname for ess_mean

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -317,7 +317,7 @@ ess_median <- function(x, ...) {
 #' @export
 ess_mean <- function(x, ...) UseMethod("ess_mean")
 
-#' @rdname ess_quantile
+#' @rdname ess_mean
 #' @export
 ess_mean.default <- function(x, ...) {
   .ess(.split_chains(x))

--- a/man/ess_mean.Rd
+++ b/man/ess_mean.Rd
@@ -2,10 +2,13 @@
 % Please edit documentation in R/convergence.R
 \name{ess_mean}
 \alias{ess_mean}
+\alias{ess_mean.default}
 \alias{ess_mean.rvar}
 \title{Effective sample size for the mean}
 \usage{
 ess_mean(x, ...)
+
+\method{ess_mean}{default}(x, ...)
 
 \method{ess_mean}{rvar}(x, ...)
 }

--- a/man/ess_quantile.Rd
+++ b/man/ess_quantile.Rd
@@ -5,7 +5,6 @@
 \alias{ess_quantile.default}
 \alias{ess_quantile.rvar}
 \alias{ess_median}
-\alias{ess_mean.default}
 \title{Effective sample sizes for quantiles}
 \usage{
 ess_quantile(x, probs = c(0.05, 0.95), ...)
@@ -15,8 +14,6 @@ ess_quantile(x, probs = c(0.05, 0.95), ...)
 \method{ess_quantile}{rvar}(x, probs = c(0.05, 0.95), names = TRUE, ...)
 
 ess_median(x, ...)
-
-\method{ess_mean}{default}(x, ...)
 }
 \arguments{
 \item{x}{(multiple options) One of:


### PR DESCRIPTION
#### Summary

`ess_mean.default` was pointing to the ess_quantile documentation page, this fixes it to point to the `ess_mean` page

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)