### PR TITLE
use the same equation in ess_sd as in mcse_sd

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -357,7 +357,10 @@ ess_sd <- function(x, ...) UseMethod("ess_sd")
 #' @rdname ess_sd
 #' @export
 ess_sd.default <- function(x, ...) {
-  .ess(.split_chains(abs(x-mean(x))))
+  # var/sd are not a simple expectation of g(X), e.g. variance
+  # has (X-E[X])^2. The following ESS is based on a relevant quantity
+  # in the computation and is empirically a good choice.
+  .ess(.split_chains((x-mean(x))^2))
 }
 
 #' @rdname ess_sd

--- a/tests/testthat/test-convergence.R
+++ b/tests/testthat/test-convergence.R
@@ -19,7 +19,7 @@ test_that("ess diagnostics return reasonable values", {
   expect_true(ess > 250 & ess < 310)
 
   ess <- ess_sd(tau)
-  expect_true(ess > 250 & ess < 310)
+  expect_true(ess > 230 & ess < 280)
 
   ess <- ess_bulk(tau)
   expect_true(ess > 230 & ess < 280)


### PR DESCRIPTION
@sethaxen pointed out that PR #266 had made the change only in `mcse_sd()`, but based on the same justification, the change should have been made to `ess_sd()`, too. This makes the change for `ess_sd()` and updates the test value range for `ess_sd()`.