### PR TITLE
Fix typo in _pkgdown.yml

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -74,7 +74,7 @@ articles:
 reference:
   - title: "Overview"
     desc: >
-      Pacakge overview and global options
+      Package overview and global options
     contents:
       - posterior-package
   - title: "Draws objects and formats"


### PR DESCRIPTION
#### Summary

closes #404, thanks to @ctholley

Fixes typo in _pkgdown.yml

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)