### PR TITLE
Minor update of documentation (spell-check)

### DIFF
--- a/R/pit.R
+++ b/R/pit.R
@@ -33,7 +33,7 @@
 #'   The draws in `x` can further be provided (log-)weights in
 #    `weights`, which enables for example the computation of LOO-PITs.
 #'
-#'   If `y` and `x` are discrete, randomisation is used to obtain continuous PIT
+#'   If `y` and `x` are discrete, randomization is used to obtain continuous PIT
 #'   values. (see, e.g., Czado, C., Gneiting, T., Held, L.: Predictive model
 #'   assessment for count data.  Biometrics 65(4), 1254–1261 (2009).)
 #'

--- a/R/rvar-print.R
+++ b/R/rvar-print.R
@@ -11,7 +11,7 @@
 #'   output. If `TRUE`, the [pillar::style_num()] functions may be used to
 #'   produce strings containing control sequences to produce colored output on
 #'   the terminal.
-#' @param width The maxmimum width used to print out lists of factor levels
+#' @param width The maximum width used to print out lists of factor levels
 #'   for [`rvar_factor`]s. See [format()].
 #' @param vec.len (nonnegative integer) How many 'first few' elements are
 #'   displayed of each vector. If `NULL`, defaults to

--- a/R/rvar-slice.R
+++ b/R/rvar-slice.R
@@ -6,7 +6,7 @@
 #' @param i,... indices; see *Details*.
 #' @param drop (logical) Should singular dimensions be dropped when slicing
 #' array [`rvar`]s? Unlike base array slicing operations, defaults to `FALSE`.
-#' @param value (`rvar` or coercable to `rvar`) Value to insert into
+#' @param value (`rvar` or coercible to `rvar`) Value to insert into
 #' `x` at the location determined by the indices.
 #'
 #' @details

--- a/man/pit.Rd
+++ b/man/pit.Rd
@@ -53,7 +53,7 @@ the elements of \code{y} and \code{x} are matched.
 
 The draws in \code{x} can further be provided (log-)weights in
 
-If \code{y} and \code{x} are discrete, randomisation is used to obtain continuous PIT
+If \code{y} and \code{x} are discrete, randomization is used to obtain continuous PIT
 values. (see, e.g., Czado, C., Gneiting, T., Held, L.: Predictive model
 assessment for count data.  Biometrics 65(4), 1254–1261 (2009).)
 }

--- a/man/print.rvar.Rd
+++ b/man/print.rvar.Rd
@@ -56,7 +56,7 @@ output. If \code{TRUE}, the \code{\link[pillar:style_subtle]{pillar::style_num()
 produce strings containing control sequences to produce colored output on
 the terminal.}
 
-\item{width}{The maxmimum width used to print out lists of factor levels
+\item{width}{The maximum width used to print out lists of factor levels
 for \code{\link{rvar_factor}}s. See \code{\link[=format]{format()}}.}
 
 \item{vec.len}{(nonnegative integer) How many 'first few' elements are

--- a/man/rvar-slice.Rd
+++ b/man/rvar-slice.Rd
@@ -21,7 +21,7 @@
 
 \item{i, ...}{indices; see \emph{Details}.}
 
-\item{value}{(\code{rvar} or coercable to \code{rvar}) Value to insert into
+\item{value}{(\code{rvar} or coercible to \code{rvar}) Value to insert into
 \code{x} at the location determined by the indices.}
 
 \item{drop}{(logical) Should singular dimensions be dropped when slicing


### PR DESCRIPTION
#### Summary

Running `devtools::spell_check()` revealed some minor typos and en-US/en-GB inconsistencies.
This PR fixes the detected inconsistencies in the documentation assuming en-US as default.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)