### PR TITLE
Add `truncate` argument to `uniformity_test()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # posterior 1.7.0
 
+### Enhancements
+
+* Add `truncate` argument to `uniformity_test()` to allow for custom truncation
+
 ### Bug Fixes
 
 * Fix several minor issues occurring in edge cases.
@@ -9,7 +13,7 @@
 * Extend and export several functions related to the generalized
 Pareto distribution for use in other packages. (#408)
 * Support Pareto PIT functionality via `pareto_pit`. (#435)
-* Allow more warnings to be turned off via option 
+* Allow more warnings to be turned off via option
 `posterior.warn_on_merge_chains`.
 * Improve documentation in many places.
 * Improve tests by checking for edge cases.
@@ -41,7 +45,7 @@ Pareto distribution for use in other packages. (#408)
   `pareto_khat_threshold()`, `pareto_min_ss()`, `pareto_convergence_rate()`)
 * `thin_draws()` now automatically thins draws based on ESS by default,
   and non-integer thinning is possible.
-* Matrix multiplication of `rvar`s can now be done with the base matrix 
+* Matrix multiplication of `rvar`s can now be done with the base matrix
   multiplication operator (`%*%`) instead of `%**%` in R >= 4.3.
 * `variables()`, `variables<-()`, `set_variables()`, and `nvariables()` now
   support a `with_indices` argument, which determines whether variable names
@@ -49,8 +53,8 @@ Pareto distribution for use in other packages. (#408)
   (#208).
 * Add `extract_variable_array()` function to extract variables with indices
   into arrays of iterations x chains x any remaining dimensions (#340).
-* For types that support `factor` variables (`draws_df`, `draws_list`, and 
-  `draws_rvars`), `extract_variable()` and `extract_variable_matrix()` can 
+* For types that support `factor` variables (`draws_df`, `draws_list`, and
+  `draws_rvars`), `extract_variable()` and `extract_variable_matrix()` can
   now return `factor`s.
 
 # posterior 1.5.0
@@ -72,7 +76,7 @@ Pareto distribution for use in other packages. (#408)
 ### Bug Fixes
 
 * Ensure `rfun()` works with primitive functions (#290) and dots arguments (#291).
-* Provide implementations of `vctrs::vec_proxy_equal()`, 
+* Provide implementations of `vctrs::vec_proxy_equal()`,
 `vctrs::vec_proxy_compare()`, and `vctrs::vec_proxy_order()`.
 * Minor future-proofing of `cbind(<rvar>)`, `rbind(<rvar>)`, and `chol(<rvar>)`
   for R 4.4 (#304).
@@ -84,8 +88,8 @@ Pareto distribution for use in other packages. (#408)
 
 ### Bug Fixes
 
-* Delay applying `tibble::num()` formatting to output from `summarise_draws()` 
-  until `print()` is called so that summary output can be easily converted to a 
+* Delay applying `tibble::num()` formatting to output from `summarise_draws()`
+  until `print()` is called so that summary output can be easily converted to a
   vanilla data frame (#275).
 
 
@@ -99,18 +103,18 @@ Pareto distribution for use in other packages. (#408)
 * The `draws_df()`, `draws_list()`, and `draws_rvars()` formats now support
   discrete variables stored as `factors` / `ordered`s (or `rvar_factor`s /
   `rvar_ordered`s). If converted to formats that do not support discrete
-  variables with named levels (`draws_matrix()` and `draws_array()`), 
+  variables with named levels (`draws_matrix()` and `draws_array()`),
   factor-like variables are converted to `numeric`s.
 * Made `match()` and `%in%` generic and added support for `rvar`s to both
   functions.
 * Added `modal_category()`, `entropy()`, and `dissent()` functions for
   summarizing discrete draws.
-* Allow lists of draws objects to be passed as the first argument to 
+* Allow lists of draws objects to be passed as the first argument to
   `bind_draws()` (#253).
 * Improving formatting of `summarise_draws` output via `tibble::num`.
 * `print.rvar()` and `format.rvar()` now default to a smaller number of
   significant digits in more cases, including when printing in data frames.
-  This is controlled by the new `"posterior.digits"` option (see 
+  This is controlled by the new `"posterior.digits"` option (see
   `help("posterior-package")`).
 * Implemented faster `vec_proxy.rvar()` and `vec_restore.rvar()`, improving
   performance of `rvar`s in `tibble`s (and elsewhere `vctrs` is used).
@@ -144,9 +148,9 @@ Pareto distribution for use in other packages. (#408)
 * Support remaining modes of `diag()` for `rvar`s (#246).
 * Better parsing for named indices in `as_draws_rvars()`, including nested use
 of `[`, like `x[y[1],2]` (#243).
-* Allow 0-length `rvar`s with `ndraws() > 1` (#242). 
+* Allow 0-length `rvar`s with `ndraws() > 1` (#242).
 * Ensure 0-length `rvar`s can be cast to `draws` formats (#242).
-* Don't treat length-1 `rvar`s with more than 1 dimension as scalars when 
+* Don't treat length-1 `rvar`s with more than 1 dimension as scalars when
 casting to other formats (#248).
 
 
@@ -173,9 +177,9 @@ casting to other formats (#248).
 
 ### Bug Fixes
 
-* fix hidden variables in `bind_draws.draws_df` when binding 
+* fix hidden variables in `bind_draws.draws_df` when binding
 more than two objects thanks to Jouni Helske (#204)
-* fix output of `pillar::glimpse()` when used on a data frame containing 
+* fix output of `pillar::glimpse()` when used on a data frame containing
 `rvar`s (#210)
 * drop `"draws"` and `"draws_df"` classes from `draws_df` objects if meta data
 columns are removed by a `dplyr` operation (#202)
@@ -187,7 +191,7 @@ columns are removed by a `dplyr` operation (#202)
 
 ### Enhancements
 
-* use `matrixStats` to speed up convergence functions (#190) and 
+* use `matrixStats` to speed up convergence functions (#190) and
 `rvar` summaries (#200)
 
 ### Bug Fixes
@@ -200,7 +204,7 @@ Karl Dunkle Werner and Alexey Stukalov (#188)
 ### Other Changes
 
 * No longer check for constant-per-chain input in effective
-sample size diagnostics as this is overly conservative 
+sample size diagnostics as this is overly conservative
 especially for `ess_tail`. (#198)
 
 

--- a/R/uniformity_test.R
+++ b/R/uniformity_test.R
@@ -29,6 +29,10 @@
 #' @param pit Numeric vector of PIT values in `[0, 1]`.
 #' @param test Character string. One of `"POT"`, `"PIET"`, or `"PRIT"`.
 #'   See details above.
+#' @param truncate Boolean. Determines whether the truncated (TRUE) or
+#'   untruncated (FALSE) Cauchy combination test (CCT) is used. By default it
+#'   is NULL in which case the truncated CCT is computed for `POT` and `PRIT`
+#'   and the untruncated CCT is computed for `PIET`.
 #'
 #' @return A list with components:
 #'   * `pvalue`: Global p-value from the Cauchy combination test.
@@ -49,13 +53,10 @@
 #'   correlations. arXiv preprint arXiv:2506.12489.
 #'
 #' @export
-uniformity_test <- function(pit, test) {
+uniformity_test <- function(pit, test, truncate = NULL) {
 
-  choices <- c("POT", "PRIT", "PIET")
-  if (!test %in% choices) {
-    stop("'test' should be one of ", paste(dQuote(choices), collapse = ", "), call. = FALSE)
-  }
-  test <- match.arg(test, choices = choices)
+  test <- rlang::arg_match(test, values = c("POT", "PRIT", "PIET"))
+  if (is.null(truncate)) truncate <- (test != "PIET")
 
   test_fn <- switch(test,
       POT  = .pot_test,
@@ -67,7 +68,7 @@ uniformity_test <- function(pit, test) {
     std_cauchy_values    <- .compute_cauchy(test_fn(pit_sorted))
     p_value_CCT          <- .cauchy_combination_test(
       test_fn(pit),
-      truncate = test != "PIET"
+      truncate = truncate
     )
     pointwise_contributions  <- .compute_shapley_values(std_cauchy_values)
 
@@ -83,9 +84,9 @@ uniformity_test <- function(pit, test) {
 
 #' Compute Shapley values
 #'
-#' Calculates the average marginal contribution of players across 
+#' Calculates the average marginal contribution of players across
 #' all random arrival orders in a cooperative game.
-#' Used to provide a principled approach for quantifying 
+#' Used to provide a principled approach for quantifying
 #' point-specific influences in a way that reflects local miscalibration.
 #'
 #' @param x Numeric vector of Cauchy-transformed PIT values.
@@ -99,11 +100,11 @@ uniformity_test <- function(pit, test) {
   if (n == 1) {
     return(0)
   }
-  
+
   # Harmonic number
   # H_n = sum(1/i) for i = 1 to n
   harmonic_number <- sum(1 / seq_len(n))
-  
+
   shapley_values <- numeric(n)
   for (i in seq_len(n)) {
     mean_others <- sum(x[-i]) / (n - 1)
@@ -120,7 +121,7 @@ uniformity_test <- function(pit, test) {
 #' H0: The value obtained via the inverse CDF transformation F^(-1)(x_i)
 #' follows the distribution of X under uniformity.
 #' HA: The p-value p_(i) provides evidence against uniformity.
-#' 
+#'
 #' @param x Numeric vector of PIT values in `[0, 1]`.
 #' @return Numeric vector of p-values.
 #' @noRd
@@ -138,7 +139,7 @@ uniformity_test <- function(pit, test) {
 #' under uniformity.
 #' HA: The p-value p_(i) provides evidence against uniformity
 #' at the i-th order statistic u_(i).
-#' 
+#'
 #' @param x Numeric vector of PIT values in `[0, 1]`.
 #' @return Numeric vector of p-values.
 #' @noRd
@@ -153,12 +154,12 @@ uniformity_test <- function(pit, test) {
 }
 
 #' Pointwise Rank-based Individual Tests Combination (PRIT)
-#' 
+#'
 #' Uniformity test based on a binomial distribution.
 #' H0: The number of observations falling at or below x_i
 #' follows a binomial distribution under uniformity.
 #' HA: The p-value p_i provides evidence against uniformity.
-#' 
+#'
 #' @param x Numeric vector of PIT values in `[0, 1]`.
 #' @return Numeric vector of p-values.
 #' @noRd
@@ -168,7 +169,7 @@ uniformity_test <- function(pit, test) {
   probs1 <- pbinom(scaled_ecdf - 1, n, x)
   probs2 <- pbinom(scaled_ecdf, n, x)
   p_values <- 2 * pmin(1 - probs1, probs2)
-  
+
   return(p_values)
 }
 

--- a/man/uniformity_test.Rd
+++ b/man/uniformity_test.Rd
@@ -4,13 +4,18 @@
 \alias{uniformity_test}
 \title{Uniformity test for PIT values}
 \usage{
-uniformity_test(pit, test)
+uniformity_test(pit, test, truncate = NULL)
 }
 \arguments{
 \item{pit}{Numeric vector of PIT values in \verb{[0, 1]}.}
 
 \item{test}{Character string. One of \code{"POT"}, \code{"PIET"}, or \code{"PRIT"}.
 See details above.}
+
+\item{truncate}{Boolean. Determines whether the truncated (TRUE) or
+untruncated (FALSE) Cauchy combination test (CCT) is used. By default it
+is NULL in which case the truncated CCT is computed for \code{POT} and \code{PRIT}
+and the untruncated CCT is computed for \code{PIET}.}
 }
 \value{
 A list with components:

--- a/tests/testthat/test-uniformity_test.R
+++ b/tests/testthat/test-uniformity_test.R
@@ -29,13 +29,24 @@ test_that("uniformity_test handles single-element pit", {
   expect_equal(length(res$pointwise), 1)
   expect_equal(res$pointwise, 0)  # Shapley for n=1 is 0
   expect_true(is.finite(res$pvalue))
-  
+
 })
 
 test_that("uniformity_test errors on invalid test", {
   pit <- runif(5)
   expect_error(posterior:::uniformity_test(pit, "INVALID"),
-               "'test' should be one of")
+               "`test` must be one of")
+})
+
+test_that("uniformity_test works with custom truncation", {
+  testthat::expect_error(
+    uniformity_test(pit = c(0.8, 0.5, 0.3, 0.1), test = "POT")
+  )
+
+  testthat::expect_no_error(
+    uniformity_test(pit = c(0.8, 0.5, 0.3, 0.1), test = "POT",
+    truncate = FALSE)
+  )
 })
 
 # Tests for the dependence-aware uniformity tests ------------------------------
@@ -43,14 +54,14 @@ test_that("piet_test computes correct p-values", {
   x <- c(0.1, 0.25, 0.5, 0.75, 0.9)
   # Equivalent to 2 * min(1-x, x)
   expected <- c(0.2, 0.5, 1.0, 0.5, 0.2)
-  
+
   expect_equal(.piet_test(x), expected, tolerance = 1e-7)
 })
 
 test_that("piet_test handles boundary values of 0 and 1", {
   x <- c(0, 1)
   expected <- c(0, 0)
-  
+
   expect_equal(.piet_test(x), expected)
 })
 
@@ -58,7 +69,7 @@ test_that("piet_test handles extreme values stably", {
   # Testing values very close to 0 and 1
   x <- c(1e-17, 1 - 1e-17)
   expected <- c(2e-17, 2e-17)
-  
+
   # Tolerance needs to be adjusted for very small numbers
   expect_equal(.piet_test(x), expected, tolerance = 1e-16)
 })
@@ -67,29 +78,29 @@ test_that("piet_test handles NA, NaN, and empty inputs correctly", {
   # NA and NaN propagation
   x_na <- c(0.5, NA, NaN)
   res_na <- .piet_test(x_na)
-  
+
   expect_equal(res_na[1], 1.0)
   expect_true(is.na(res_na[2]))
   expect_true(is.nan(res_na[3]))
 })
 
 test_that("pot_test calculates correct p-values", {
-  # Manually calculating expected values for x = c(0.2, 0.8), n = 2. 
-  # Note: If X ~ Beta(1, b) then X ~ Kumaraswamy(1, b) with CDF 1 - (1 - x)^b 
+  # Manually calculating expected values for x = c(0.2, 0.8), n = 2.
+  # Note: If X ~ Beta(1, b) then X ~ Kumaraswamy(1, b) with CDF 1 - (1 - x)^b
   # and if X ~ Beta(a, 1) then X ~ Kumaraswamy(a, 1) with CDF to x^a
   # Beta(1, 2) CDF at 0.2 is 1 - (1 - 0.2)^2 = 0.36
   # Beta(2, 1) CDF at 0.8 is 0.8^2 = 0.64
   # p-values: 2 * min(0.36, 1-0.36) = 0.72; 2 * min(0.64, 1-0.64) = 0.72
   x <- c(0.8, 0.2)
   expected <- c(0.72, 0.72)
-  
+
   expect_equal(.pot_test(x), expected)
 })
 
 test_that("pot_test handles boundary values correctly", {
   x <- c(0, 1)
   expected <- c(0, 0)
-  
+
   expect_equal(.pot_test(x), expected)
 })
 
@@ -97,7 +108,7 @@ test_that("pot_test bounds p-values between 0 and 1 for extreme out-of-bounds in
   # pbeta handles values outside [0, 1] by returning 0
   x <- c(-0.5, 1.5)
   expected <- c(0, 0)
-  
+
   expect_equal(.pot_test(x), expected)
 })
 
@@ -110,12 +121,12 @@ test_that("pot_test handles NAs", {
 })
 
 test_that("prit_test computes correct p-values", {
-  # Let n = 2, x = c(0.5, 0.5) 
+  # Let n = 2, x = c(0.5, 0.5)
   # scaled_ecdf = 2 * c(1, 1) = c(2, 2)
   # probs1 = pbinom(1, 2, 0.5) = 0.75
   # probs2 = pbinom(2, 2, 0.5) = 1.00
   # p_val = 2 * min(1 - 0.75, 1.00) = 2 * 0.25 = 0.5
-  
+
   x <- c(0.5, 0.5)
   expect_equal(.prit_test(x), c(0.5, 0.5))
 })
@@ -135,14 +146,14 @@ test_that("compute_shapley_values handles empty vector and single element", {
 test_that("compute_shapley_values for simple case", {
   x <- c(1, 2)
   result <- .compute_shapley_values(x)
-  
+
   # Manual calculation for n=2:
   # harmonic_number = 1 + 1/2 = 1.5
   # For i=1: mean_others = 2/1 = 2
   # shapley[1] = (1/2)*1 + ((1.5-1)/2)*(1-2) = 0.5 - 0.25 = 0.25
   # For i=2: mean_others = 1/1 = 1
   # shapley[2] = (1/2)*2 + ((1.5-1)/2)*(2-1) = 1 + 0.25 = 1.25
-  
+
   expected <- c(0.25, 1.25)
   expect_equal(result, expected, tolerance = 1e-10)
   expect_equal(length(result), 2)
@@ -159,11 +170,11 @@ test_that("compute_shapley_values handles mixed input values", {
 test_that("cauchy_combination_test handles truncate = FALSE", {
   # avg = mean(-qcauchy(x))
   # result = 1 - pcauchy(avg)
-  
+
   x <- c(0.1, 0.2, 0.3)
   result <- .cauchy_combination_test(x, truncate = FALSE)
   expected <- 1 - pcauchy(mean(-qcauchy(x)))
-  
+
   expect_equal(result, expected, tolerance = 1e-10)
   expect_true(is.finite(result))
   expect_true(result >= 0 && result <= 1)
@@ -172,11 +183,11 @@ test_that("cauchy_combination_test handles truncate = FALSE", {
 test_that("cauchy_combination_test handles truncate = TRUE", {
   # avg = mean(-qcauchy(x))
   # result = 1 - pcauchy(avg)
-  
+
   x <- c(0.1, 0.2, 0.3, 0.4, 0.7, 0.8)
   result <- .cauchy_combination_test(x, truncate = TRUE)
   expected <- 1 - pcauchy(mean(-qcauchy(c(0.1, 0.2, 0.3, 0.4))))
-  
+
   expect_equal(result, expected, tolerance = 1e-10)
   expect_true(is.finite(result))
   expect_true(result >= 0 && result <= 1)
@@ -184,12 +195,12 @@ test_that("cauchy_combination_test handles truncate = TRUE", {
 
 test_that("cauchy_combination_test handles boundary values", {
   # x = 0: -qdf(0) = Inf and cdf(Inf) = 1 -> 1 - 1 = 0
-  # x = 1: -qdf(1) = -Inf and cdf(-Inf) = 0 -> 1 - 0 = 1 
-  
+  # x = 1: -qdf(1) = -Inf and cdf(-Inf) = 0 -> 1 - 0 = 1
+
   expect_equal(.cauchy_combination_test(0, truncate = FALSE), 0)
   expect_equal(.cauchy_combination_test(1, truncate = FALSE), 1)
   expect_true(is.nan(.cauchy_combination_test(c(0, 1), truncate = FALSE)))
-  # TODO: if 1 included in vector, CCT will always evaluate to 0 
+  # TODO: if 1 included in vector, CCT will always evaluate to 0
   # as the mean evaluates to Inf and 1 - cdf(Inf) = 1 - 1 = 0
   expect_equal(.cauchy_combination_test(c(0, 0.3, 0.4, 1), truncate = TRUE), 0)
 })
@@ -199,10 +210,10 @@ test_that("cauchy_combination_test handles boundary values", {
 test_that("compute_cauchy computes correct transformations", {
   # For x = 0.5: tan((0.5 - 0.5) * pi) = tan(0) = 0
   expect_equal(.compute_cauchy(0.5), 0, tolerance = 1e-10)
-  
+
   # For x = 0.25: tan((0.5 - 0.25) * pi) = tan(0.25 * pi) = 1
   expect_equal(.compute_cauchy(0.25), 1, tolerance = 1e-10)
-  
+
   # For x = 0.75: tan((0.5 - 0.75) * pi) = tan(-0.25 * pi) = -1
   expect_equal(.compute_cauchy(0.75), -1, tolerance = 1e-10)
 })


### PR DESCRIPTION
#### Summary

Currently, `uniformity_test()` determines automatically whether the truncated Cauchy combination test (CCT) should be used or not. This decision is based on the `test` value (POT and PRIT -> truncated CCT; PIET -> untruncated CCT).
However, there are situations in which the user should be able to change this default behaviour by customising the truncation option.

This PR adds a `truncate` argument to `uniformity_test()` which is by default `NULL` in which case it mimics the original behaviour of automatic  detection based on the `test` value.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)