### PR TITLE
fix returned k when both tails give NA

### DIFF
--- a/R/pareto_smooth.R
+++ b/R/pareto_smooth.R
@@ -345,7 +345,11 @@ pareto_smooth.default <- function(x,
     )
     right_k <- smoothed$k
 
-    k <- max(left_k, right_k, na.rm = TRUE)
+    if (is.na(left_k) && is.na(right_k)) {
+      k <- NA
+    } else {
+      k <- max(left_k, right_k, na.rm = TRUE)
+    }
     x <- smoothed$x
 
   } else {

--- a/tests/testthat/test-pareto_smooth.R
+++ b/tests/testthat/test-pareto_smooth.R
@@ -13,6 +13,18 @@ test_that("pareto_khat handles constant tail correctly", {
 })
 
 
+test_that("pareto_khat handles both tails being constant correctly", {
+
+  # left and right tails are constant, so khat should be NA in all cases
+  x <- c(rep(-100, 10), sort(rnorm(100)), rep(100, 10))
+  
+  expect_true(is.na(pareto_khat(x, tail = "left", ndraws_tail = 10)))
+  expect_true(is.na(pareto_khat(x, tail = "right", ndraws_tail = 10)))
+  expect_true(is.na(pareto_khat(x, tail = "both", ndraws_tail = 10)))
+
+})
+
+
 test_that("pareto_smooth handles non-constant x with constant tail", {
 
   # x is non-constant but the right tail is constant


### PR DESCRIPTION
When using `pareto_smooth(, tail = "both")` and both tails are such that NA is returned, the current version gives a warning
```
In max(left_k, right_k, na.rm = TRUE) :
  no non-missing arguments to max; returning -Inf
```
as `max()` is not able to compare NA and NA.

This PR adds a check for `left_k` and `right_k` being both NA. The new test fails without the fix and passes with the fix.

This warning came up when using `brms::loo_epred()` which calls `E_loo()` which checks both tails, and new loo v2.10.0 has switched to using `posterior` package for the checks

I used Claude to find the error and suggest a fix. I understand the fix. I wrote the new test.